### PR TITLE
ヘッダーの背景色を削除

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,7 +20,6 @@ body {
 
 /* Header */
 header {
-  background: #1e293b;
   border-bottom: 1px solid #334155;
   position: sticky;
   top: 0;


### PR DESCRIPTION
## 概要
ヘッダーの背景色を削除し、透明にしました。

## 変更内容
- ヘッダーの `background` プロパティを削除
- ボーダーとポジション設定は維持
- ヘッダーがページの背景色を継承するように変更

## 効果
- よりクリーンな見た目を実現
- ヘッダーがページ全体のデザインと自然に統合

🤖 Generated with [Claude Code](https://claude.ai/code)