### PR TITLE
JekyllブログにRSSフィード機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.0"
 gem "jekyll-paginate", "~> 1.1.0"
+gem "jekyll-feed", "~> 0.12"
 gem "rouge"
 
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/_config.yml
+++ b/_config.yml
@@ -2,11 +2,13 @@ title: Blog
 description: シンプルなブログ
 url: "https://username.github.io"
 baseurl: "/claude-code-blog-site"
+author: Blog Author
 markdown: kramdown
 permalink: /:year/:month/:day/:title
 highlighter: rouge
 plugins:
   - jekyll-paginate
+  - jekyll-feed
 
 paginate: 5
 paginate_path: "/page:num/"
@@ -23,6 +25,13 @@ defaults:
     values:
       layout: "post"
 
+# RSS Feed Configuration
+feed:
+  posts_limit: 20
+  excerpt_only: false
+  collections:
+    - posts
+
 exclude:
   - Gemfile
   - Gemfile.lock
@@ -32,3 +41,4 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - .github/
+  - .n8n/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
   <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  {% feed_meta %}
 </head>
 <body>
   {% include header.html %}


### PR DESCRIPTION
## 概要
JekyllブログにRSSフィード機能を追加しました。

## 変更内容

### 1. jekyll-feedプラグインの追加
- `Gemfile`に`jekyll-feed`プラグインを追加
- バージョン指定: `~> 0.12`

### 2. Jekyll設定の更新（_config.yml）
- `jekyll-feed`プラグインを有効化
- RSS フィード設定を追加：
  - 投稿数制限: 20件
  - 全文配信（excerpt_onlyをfalse）
  - 作成者情報の設定
- `.n8n/`ディレクトリをJekyllビルドから除外

### 3. HTMLテンプレートの更新
- `_layouts/default.html`に`{% feed_meta %}`タグを追加
- RSSフィードの自動検出メタタグを生成

## RSS フィードの特徴

- **URL**: `/feed.xml` でアクセス可能
- **投稿数**: 最新20件を配信
- **内容**: 記事の全文を配信
- **メタデータ**: タイトル、説明、作成者情報を含む
- **自動検出**: ブラウザでRSSフィードを自動検出可能

## 使用方法

1. サイトがデプロイされた後、`https://your-site.com/feed.xml`でRSSフィードにアクセス
2. RSSリーダーでフィードURLを登録
3. ブラウザがフィードを自動検出してアイコン表示

## 技術詳細

- jekyll-feedプラグインが自動的に`/feed.xml`を生成
- Jekyll buildプロセスで自動更新
- GitHub Pagesでも標準サポート

🤖 Generated with [Claude Code](https://claude.ai/code)