### PR TITLE
Dockerベースのn8nセルフホスト環境を追加

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,40 @@
+# PostgreSQL Database Configuration
+POSTGRES_DB=n8n
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your_strong_postgres_password_here
+POSTGRES_NON_ROOT_USER=n8n
+POSTGRES_NON_ROOT_PASSWORD=your_strong_n8n_db_password_here
+
+# n8n Configuration
+N8N_HOST=localhost
+N8N_PORT=5678
+N8N_PROTOCOL=http
+WEBHOOK_URL=http://localhost:5678
+
+# Basic Authentication (recommended for production)
+N8N_BASIC_AUTH_ACTIVE=true
+N8N_BASIC_AUTH_USER=admin
+N8N_BASIC_AUTH_PASSWORD=your_strong_n8n_password_here
+
+# Logging
+N8N_LOG_LEVEL=info
+
+# Timezone
+TIMEZONE=Asia/Tokyo
+
+# GitHub Integration
+GITHUB_OWNER=your_github_username
+GITHUB_REPO=claude-code-blog-site
+
+# Nginx Configuration (optional)
+NGINX_PORT=80
+NGINX_SSL_PORT=443
+
+# SSL Configuration (if using HTTPS)
+# N8N_PROTOCOL=https
+# WEBHOOK_URL=https://your-domain.com
+
+# Production Settings (uncomment for production use)
+# N8N_HOST=your-domain.com
+# WEBHOOK_URL=https://your-domain.com
+# N8N_PROTOCOL=https

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,25 @@
+# Environment files
+.env
+
+# SSL certificates
+ssl/*.pem
+ssl/*.key
+ssl/*.crt
+
+# Data directories (if mounted locally)
+data/
+postgres-data/
+n8n-data/
+redis-data/
+
+# Backup files
+*.sql
+*.tar.gz
+*.dump
+
+# Logs
+*.log
+
+# Temporary files
+.tmp/
+temp/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,296 @@
+# Docker n8n セルフホスト環境
+
+このディレクトリには、n8nをDockerでセルフホストするための設定ファイルが含まれています。
+
+## 📋 必要要件
+
+- Docker 20.10+
+- Docker Compose 2.0+
+- 最低 2GB RAM
+- 最低 5GB ディスク容量
+
+## 🚀 クイックスタート
+
+### 1. 自動セットアップ（推奨）
+
+```bash
+cd docker
+./setup.sh
+```
+
+セットアップスクリプトが以下を自動実行します：
+- 環境設定ファイルの作成
+- セキュアなパスワードの生成
+- 必要なディレクトリの作成
+- Docker Compose でのサービス起動
+
+### 2. 手動セットアップ
+
+```bash
+# 1. 環境設定ファイルをコピー
+cp .env.example .env
+
+# 2. .env ファイルを編集（パスワードなど）
+nano .env
+
+# 3. サービスを起動
+docker-compose up -d
+
+# 4. ログを確認
+docker-compose logs -f
+```
+
+## 🏗️ アーキテクチャ
+
+このセットアップには以下のサービスが含まれます：
+
+### コアサービス
+
+- **n8n**: メインアプリケーション（ポート: 5678）
+- **PostgreSQL**: データベース（永続化）
+- **Redis**: キューとキャッシュ
+- **Nginx**: リバースプロキシ（ポート: 80/443）
+
+### データ永続化
+
+- `postgres_data`: PostgreSQLデータ
+- `redis_data`: Redisデータ
+- `n8n_data`: n8n設定とワークフローデータ
+
+## 🔧 設定オプション
+
+### 環境変数（.envファイル）
+
+#### データベース設定
+```env
+POSTGRES_DB=n8n
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your_strong_password
+POSTGRES_NON_ROOT_USER=n8n
+POSTGRES_NON_ROOT_PASSWORD=your_n8n_password
+```
+
+#### n8n基本設定
+```env
+N8N_HOST=localhost
+N8N_PORT=5678
+N8N_PROTOCOL=http
+WEBHOOK_URL=http://localhost:5678
+```
+
+#### 認証設定
+```env
+N8N_BASIC_AUTH_ACTIVE=true
+N8N_BASIC_AUTH_USER=admin
+N8N_BASIC_AUTH_PASSWORD=your_admin_password
+```
+
+#### GitHub連携
+```env
+GITHUB_OWNER=your_username
+GITHUB_REPO=claude-code-blog-site
+```
+
+## 🌐 ネットワーク構成
+
+### 開発環境
+- n8n UI: http://localhost:5678
+- Nginx: http://localhost:80
+
+### プロダクション環境
+- HTTPS対応（SSL証明書設定）
+- カスタムドメイン設定
+- セキュリティヘッダー
+
+## 📁 ディレクトリ構造
+
+```
+docker/
+├── docker-compose.yml     # Docker Compose設定
+├── .env.example          # 環境変数テンプレート
+├── .env                  # 環境変数（gitignore）
+├── nginx.conf            # Nginx設定
+├── init-data.sh          # データベース初期化
+├── setup.sh              # 自動セットアップスクリプト
+├── ssl/                  # SSL証明書（プロダクション用）
+└── README.md             # このファイル
+```
+
+## 🔐 セキュリティ設定
+
+### Basic認証
+管理画面へのアクセスにBasic認証を使用：
+- ユーザー名: `N8N_BASIC_AUTH_USER`
+- パスワード: `N8N_BASIC_AUTH_PASSWORD`
+
+### SSL/TLS（プロダクション推奨）
+
+1. SSL証明書を `ssl/` ディレクトリに配置：
+   ```
+   ssl/
+   ├── cert.pem
+   └── key.pem
+   ```
+
+2. .envファイルでHTTPS設定を有効化：
+   ```env
+   N8N_PROTOCOL=https
+   WEBHOOK_URL=https://your-domain.com
+   ```
+
+3. nginx.confのHTTPS設定のコメントアウトを解除
+
+### ネットワークセキュリティ
+- Rate limiting設定済み
+- セキュリティヘッダー設定済み
+- 内部ネットワーク分離
+
+## 🚦 サービス管理
+
+### 基本コマンド
+
+```bash
+# サービス起動
+docker-compose up -d
+
+# サービス停止
+docker-compose down
+
+# サービス再起動
+docker-compose restart
+
+# ログ確認
+docker-compose logs -f [service_name]
+
+# サービス状態確認
+docker-compose ps
+
+# リソース使用量確認
+docker stats
+```
+
+### メンテナンス
+
+```bash
+# データベースバックアップ
+docker-compose exec postgres pg_dump -U n8n n8n > backup.sql
+
+# データベース復元
+docker-compose exec -T postgres psql -U n8n n8n < backup.sql
+
+# n8nデータバックアップ
+docker-compose exec n8n tar czf /tmp/n8n-backup.tar.gz /home/node/.n8n
+docker cp container_name:/tmp/n8n-backup.tar.gz ./n8n-backup.tar.gz
+```
+
+## 📊 モニタリング
+
+### ヘルスチェック
+- PostgreSQL: `docker-compose exec postgres pg_isready`
+- Redis: `docker-compose exec redis redis-cli ping`
+- n8n: http://localhost/health
+
+### ログ監視
+```bash
+# 全サービスのログ
+docker-compose logs -f
+
+# 特定サービスのログ
+docker-compose logs -f n8n
+docker-compose logs -f postgres
+docker-compose logs -f nginx
+```
+
+## 🔄 ワークフロー管理
+
+### ワークフローのインポート
+
+1. n8n管理画面にアクセス
+2. 設定 → インポート/エクスポート
+3. `../.n8n/workflows/` のJSONファイルをインポート
+
+### 認証情報の設定
+
+1. 設定 → 認証情報
+2. GitHub APIトークンを設定
+3. 必要に応じて他の認証情報も設定
+
+## 🐛 トラブルシューティング
+
+### よくある問題
+
+#### 1. サービスが起動しない
+```bash
+# ログを確認
+docker-compose logs
+
+# ポートの競合チェック
+netstat -tulpn | grep :5678
+```
+
+#### 2. データベース接続エラー
+```bash
+# PostgreSQLの状態確認
+docker-compose exec postgres pg_isready -U n8n -d n8n
+
+# 接続テスト
+docker-compose exec n8n sh -c 'echo "SELECT 1" | psql -h postgres -U n8n -d n8n'
+```
+
+#### 3. パフォーマンス問題
+```bash
+# リソース使用量確認
+docker stats
+
+# メモリ制限の調整（docker-compose.yml）
+services:
+  n8n:
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+```
+
+#### 4. ワークフローが実行されない
+- Basic認証設定の確認
+- GitHub webhookのURL確認
+- 認証トークンの有効性確認
+
+### ログ分析
+
+```bash
+# エラーログの抽出
+docker-compose logs n8n 2>&1 | grep -i error
+
+# 特定時間範囲のログ
+docker-compose logs --since="2024-01-01T00:00:00" --until="2024-01-01T23:59:59"
+```
+
+## 🔄 アップデート
+
+### n8nのアップデート
+
+```bash
+# 最新イメージを取得
+docker-compose pull
+
+# サービスを再作成
+docker-compose up -d --force-recreate
+```
+
+### 設定の更新
+
+```bash
+# docker-compose.yml変更後
+docker-compose up -d --force-recreate
+
+# .env変更後
+docker-compose down && docker-compose up -d
+```
+
+## 📚 参考資料
+
+- [n8n Documentation](https://docs.n8n.io/)
+- [Docker Compose Documentation](https://docs.docker.com/compose/)
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+- [Nginx Documentation](https://nginx.org/en/docs/)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,127 @@
+version: '3.8'
+
+services:
+  # PostgreSQL Database
+  postgres:
+    image: postgres:15
+    container_name: n8n_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-n8n}
+      POSTGRES_USER: ${POSTGRES_USER:-n8n}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_NON_ROOT_USER: ${POSTGRES_NON_ROOT_USER:-n8n}
+      POSTGRES_NON_ROOT_PASSWORD: ${POSTGRES_NON_ROOT_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init-data.sh:/docker-entrypoint-initdb.d/init-data.sh
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -h localhost -U ${POSTGRES_USER:-n8n} -d ${POSTGRES_DB:-n8n}']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - n8n_network
+
+  # Redis Cache (optional but recommended)
+  redis:
+    image: redis:7-alpine
+    container_name: n8n_redis
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - n8n_network
+
+  # n8n Application
+  n8n:
+    image: n8nio/n8n:latest
+    container_name: n8n_app
+    restart: unless-stopped
+    environment:
+      # Database
+      DB_TYPE: postgresdb
+      DB_POSTGRESDB_HOST: postgres
+      DB_POSTGRESDB_PORT: 5432
+      DB_POSTGRESDB_DATABASE: ${POSTGRES_DB:-n8n}
+      DB_POSTGRESDB_USER: ${POSTGRES_NON_ROOT_USER:-n8n}
+      DB_POSTGRESDB_PASSWORD: ${POSTGRES_NON_ROOT_PASSWORD}
+      
+      # Redis Queue
+      QUEUE_BULL_REDIS_HOST: redis
+      QUEUE_BULL_REDIS_PORT: 6379
+      
+      # n8n Configuration
+      N8N_HOST: ${N8N_HOST:-localhost}
+      N8N_PORT: 5678
+      N8N_PROTOCOL: ${N8N_PROTOCOL:-http}
+      WEBHOOK_URL: ${WEBHOOK_URL:-http://localhost:5678}
+      
+      # Security
+      N8N_BASIC_AUTH_ACTIVE: ${N8N_BASIC_AUTH_ACTIVE:-true}
+      N8N_BASIC_AUTH_USER: ${N8N_BASIC_AUTH_USER}
+      N8N_BASIC_AUTH_PASSWORD: ${N8N_BASIC_AUTH_PASSWORD}
+      
+      # Execution
+      EXECUTIONS_PROCESS: main
+      EXECUTIONS_DATA_SAVE_ON_ERROR: all
+      EXECUTIONS_DATA_SAVE_ON_SUCCESS: all
+      EXECUTIONS_DATA_MAX_AGE: 168
+      
+      # Logging
+      N8N_LOG_LEVEL: ${N8N_LOG_LEVEL:-info}
+      N8N_LOG_OUTPUT: console
+      
+      # Timezone
+      GENERIC_TIMEZONE: ${TIMEZONE:-Asia/Tokyo}
+      TZ: ${TIMEZONE:-Asia/Tokyo}
+      
+      # GitHub Integration
+      GITHUB_OWNER: ${GITHUB_OWNER}
+      GITHUB_REPO: ${GITHUB_REPO}
+      
+    ports:
+      - "${N8N_PORT:-5678}:5678"
+    volumes:
+      - n8n_data:/home/node/.n8n
+      - ../workflows:/home/node/.n8n/workflows:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - n8n_network
+
+  # Nginx Reverse Proxy (optional)
+  nginx:
+    image: nginx:alpine
+    container_name: n8n_nginx
+    restart: unless-stopped
+    ports:
+      - "${NGINX_PORT:-80}:80"
+      - "${NGINX_SSL_PORT:-443}:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    depends_on:
+      - n8n
+    networks:
+      - n8n_network
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  n8n_data:
+    driver: local
+
+networks:
+  n8n_network:
+    driver: bridge

--- a/docker/init-data.sh
+++ b/docker/init-data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Create n8n user and database if they don't exist
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    -- Create n8n user if not exists
+    DO \$\$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$POSTGRES_NON_ROOT_USER') THEN
+            CREATE USER $POSTGRES_NON_ROOT_USER WITH PASSWORD '$POSTGRES_NON_ROOT_PASSWORD';
+        END IF;
+    END
+    \$\$;
+
+    -- Grant privileges
+    GRANT ALL PRIVILEGES ON DATABASE $POSTGRES_DB TO $POSTGRES_NON_ROOT_USER;
+    GRANT ALL ON SCHEMA public TO $POSTGRES_NON_ROOT_USER;
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $POSTGRES_NON_ROOT_USER;
+    GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO $POSTGRES_NON_ROOT_USER;
+    
+    -- Set default privileges for future objects
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO $POSTGRES_NON_ROOT_USER;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO $POSTGRES_NON_ROOT_USER;
+EOSQL
+
+echo "Database initialization completed successfully!"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,126 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream n8n {
+        server n8n:5678;
+    }
+
+    # Rate limiting
+    limit_req_zone $binary_remote_addr zone=n8n_limit:10m rate=10r/s;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    server {
+        listen 80;
+        server_name _;
+
+        # Rate limiting
+        limit_req zone=n8n_limit burst=20 nodelay;
+
+        # Client body size limit
+        client_max_body_size 50M;
+
+        # Timeout settings
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
+        location / {
+            proxy_pass http://n8n;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # Disable proxy buffering for real-time responses
+            proxy_buffering off;
+        }
+
+        # Webhook endpoint with extended timeouts
+        location /webhook {
+            proxy_pass http://n8n;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # Extended timeouts for webhook processing
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+        }
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+    }
+
+    # HTTPS configuration (uncomment and configure for production)
+    # server {
+    #     listen 443 ssl http2;
+    #     server_name your-domain.com;
+    #
+    #     ssl_certificate /etc/nginx/ssl/cert.pem;
+    #     ssl_certificate_key /etc/nginx/ssl/key.pem;
+    #     ssl_protocols TLSv1.2 TLSv1.3;
+    #     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
+    #     ssl_prefer_server_ciphers off;
+    #     ssl_session_cache shared:SSL:10m;
+    #
+    #     # Rate limiting
+    #     limit_req zone=n8n_limit burst=20 nodelay;
+    #
+    #     # Client body size limit
+    #     client_max_body_size 50M;
+    #
+    #     location / {
+    #         proxy_pass http://n8n;
+    #         proxy_set_header Host $host;
+    #         proxy_set_header X-Real-IP $remote_addr;
+    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #         proxy_set_header X-Forwarded-Proto https;
+    #         
+    #         # WebSocket support
+    #         proxy_http_version 1.1;
+    #         proxy_set_header Upgrade $http_upgrade;
+    #         proxy_set_header Connection "upgrade";
+    #         
+    #         # Disable proxy buffering for real-time responses
+    #         proxy_buffering off;
+    #     }
+    #
+    #     location /webhook {
+    #         proxy_pass http://n8n;
+    #         proxy_set_header Host $host;
+    #         proxy_set_header X-Real-IP $remote_addr;
+    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #         proxy_set_header X-Forwarded-Proto https;
+    #         
+    #         # Extended timeouts for webhook processing
+    #         proxy_connect_timeout 300s;
+    #         proxy_send_timeout 300s;
+    #         proxy_read_timeout 300s;
+    #     }
+    # }
+
+    # Redirect HTTP to HTTPS (uncomment for production with SSL)
+    # server {
+    #     listen 80;
+    #     server_name your-domain.com;
+    #     return 301 https://$server_name$request_uri;
+    # }
+}

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# n8n Docker Setup Script
+# This script helps you set up n8n with Docker Compose
+
+set -e
+
+echo "🚀 n8n Docker セットアップスクリプト"
+echo "=================================="
+
+# Check if Docker and Docker Compose are installed
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker がインストールされていません。"
+    echo "   https://docs.docker.com/get-docker/ からインストールしてください。"
+    exit 1
+fi
+
+if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+    echo "❌ Docker Compose がインストールされていません。"
+    echo "   https://docs.docker.com/compose/install/ からインストールしてください。"
+    exit 1
+fi
+
+echo "✅ Docker と Docker Compose が利用可能です。"
+
+# Check if .env file exists
+if [ ! -f ".env" ]; then
+    echo "📝 .env ファイルが見つかりません。テンプレートから作成します..."
+    cp .env.example .env
+    echo "✅ .env ファイルを作成しました。"
+    echo "⚠️  重要: .env ファイルを編集して、適切なパスワードと設定を入力してください。"
+    echo ""
+    
+    # Generate secure passwords
+    echo "🔐 セキュアなパスワードを生成中..."
+    POSTGRES_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
+    N8N_DB_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
+    N8N_AUTH_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
+    
+    # Update .env file with generated passwords
+    sed -i.bak "s/your_strong_postgres_password_here/$POSTGRES_PASSWORD/" .env
+    sed -i.bak "s/your_strong_n8n_db_password_here/$N8N_DB_PASSWORD/" .env
+    sed -i.bak "s/your_strong_n8n_password_here/$N8N_AUTH_PASSWORD/" .env
+    rm .env.bak
+    
+    echo "✅ セキュアなパスワードを生成して設定しました。"
+    echo ""
+else
+    echo "✅ .env ファイルが見つかりました。"
+fi
+
+# Create necessary directories
+echo "📁 必要なディレクトリを作成中..."
+mkdir -p ssl
+mkdir -p ../workflows
+echo "✅ ディレクトリを作成しました。"
+
+# Prompt for basic configuration
+echo ""
+echo "🔧 基本設定を入力してください:"
+echo ""
+
+read -p "GitHub ユーザー名を入力してください: " GITHUB_OWNER
+read -p "GitHub リポジトリ名を入力してください [claude-code-blog-site]: " GITHUB_REPO
+GITHUB_REPO=${GITHUB_REPO:-claude-code-blog-site}
+
+# Update .env file with user input
+sed -i.bak "s/your_github_username/$GITHUB_OWNER/" .env
+sed -i.bak "s/claude-code-blog-site/$GITHUB_REPO/" .env
+rm .env.bak
+
+echo ""
+echo "🐳 Docker Compose でサービスを開始します..."
+
+# Start services
+docker-compose up -d
+
+echo ""
+echo "⏳ サービスの起動を待機中..."
+sleep 10
+
+# Check if services are running
+if docker-compose ps | grep -q "Up"; then
+    echo "✅ n8n が正常に起動しました！"
+    echo ""
+    echo "🌐 アクセス情報:"
+    echo "   URL: http://localhost:5678"
+    echo "   ユーザー名: admin"
+    echo "   パスワード: .env ファイルの N8N_BASIC_AUTH_PASSWORD を確認"
+    echo ""
+    echo "📋 次のステップ:"
+    echo "   1. ブラウザで http://localhost:5678 にアクセス"
+    echo "   2. 管理画面にログイン"
+    echo "   3. GitHub Personal Access Token を設定"
+    echo "   4. ワークフローをインポート"
+    echo ""
+    echo "📚 詳細な設定方法は README.md を参照してください。"
+else
+    echo "❌ サービスの起動に失敗しました。"
+    echo "   ログを確認してください: docker-compose logs"
+fi
+
+echo ""
+echo "🎉 セットアップが完了しました！"


### PR DESCRIPTION
## 概要
n8nのDockerベースセルフホスト環境を構築しました。本格的な運用に対応した設定とスクリプトを提供します。

## 追加されたファイル

### Docker設定
- **`docker/docker-compose.yml`**: 完全なDocker Compose設定
- **`docker/.env.example`**: 環境変数テンプレート
- **`docker/nginx.conf`**: 本格運用対応のNginx設定

### セットアップ・管理スクリプト
- **`docker/setup.sh`**: 自動セットアップスクリプト
- **`docker/init-data.sh`**: データベース初期化スクリプト

### ドキュメント
- **`docker/README.md`**: 詳細な設定・運用ガイド
- **`docker/.gitignore`**: セキュリティファイルの除外設定

## システム構成

### コアサービス
- **n8n**: メインアプリケーション (localhost:5678)
- **PostgreSQL 15**: 永続データストレージ
- **Redis 7**: キューとキャッシュシステム
- **Nginx**: リバースプロキシ (localhost:80)

### セキュリティ機能
- Basic認証によるアクセス制御
- 自動生成される強力なパスワード
- Rate limiting (10req/s)
- セキュリティヘッダー設定
- SSL/TLS対応準備

### 運用機能
- ヘルスチェック機能
- ログ管理
- データバックアップ対応
- 自動復旧機能

## クイックスタート

```bash
cd docker
./setup.sh
```

セットアップスクリプトが以下を自動実行：
1. 環境設定ファイル作成
2. セキュアなパスワード生成
3. Docker Compose起動
4. 動作確認

## 主要な設定オプション

### 開発環境
- HTTP接続 (localhost:5678)
- Basic認証有効
- 日本時間設定

### プロダクション環境
- HTTPS対応
- カスタムドメイン設定
- SSL証明書配置
- セキュリティ強化

## データ永続化

- PostgreSQLデータ: `postgres_data` volume
- Redisデータ: `redis_data` volume  
- n8n設定: `n8n_data` volume
- 既存ワークフロー: `../workflows` マウント

## 運用・管理

### 基本操作
```bash
docker-compose up -d      # 起動
docker-compose down       # 停止
docker-compose logs -f    # ログ監視
```

### バックアップ
```bash
# データベースバックアップ
docker-compose exec postgres pg_dump -U n8n n8n > backup.sql

# n8n設定バックアップ
docker-compose exec n8n tar czf /tmp/n8n-backup.tar.gz /home/node/.n8n
```

## GitHub Webhookの設定

1. n8n起動後、http://localhost:5678 にアクセス
2. Basic認証でログイン (setup.sh実行時に表示)
3. 既存ワークフローをインポート
4. GitHub Personal Access Tokenを設定
5. GitHub Webhook URL: `http://your-server:5678/webhook/github-webhook`

詳細な設定手順は `docker/README.md` をご確認ください。

🤖 Generated with [Claude Code](https://claude.ai/code)