### PR TITLE
URLと長いテキストの表示を修正

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,6 +91,7 @@ main {
 .post-excerpt {
   color: #cbd5e1;
   line-height: 1.7;
+  word-break: break-all;
 }
 
 /* Single Post */
@@ -132,6 +133,7 @@ main {
 .post-content p {
   margin-bottom: 20px;
   line-height: 1.8;
+  word-break: break-all;
 }
 
 .post-content ul, .post-content ol {


### PR DESCRIPTION
## Summary
- URLなどの長いテキストがコンテナから突き抜けて表示される問題を修正
- `.post-content p`と`.post-excerpt`に`word-break: break-all`を適用

## 変更内容
- `assets/css/style.css`の`.post-content p`セレクタに`word-break: break-all`プロパティを追加
- `assets/css/style.css`の`.post-excerpt`セレクタに`word-break: break-all`プロパティを追加

## Test plan
- [ ] ブログ記事でURLが含まれる段落の表示を確認
- [ ] 記事一覧ページでexcerpt部分の長いテキストの表示を確認
- [ ] レスポンシブデザインでの表示を確認

🤖 Generated with [Claude Code](https://claude.ai/code)