### PR TITLE
コンテンツ取得に失敗した記事を要約対象から除外

### DIFF
--- a/scripts/fetch_and_summarize.py
+++ b/scripts/fetch_and_summarize.py
@@ -314,6 +314,11 @@ excerpt: "{excerpt}"
                 # 記事内容を取得
                 content = self.extract_article_content(url)
                 
+                # コンテンツ取得に失敗した場合はスキップ
+                if content == "コンテンツの取得に失敗しました":
+                    logger.warning(f"Skipping entry due to content extraction failure: {title}")
+                    continue
+                
                 # 要約を生成
                 summary = self.summarize_with_gemini(title, url, content)
                 


### PR DESCRIPTION
## Summary
- コンテンツ取得に失敗した記事をブログ投稿の対象から除外する機能を追加
- より質の高いブログ投稿を生成

## 変更内容
- `extract_article_content`が「コンテンツの取得に失敗しました」を返した場合にスキップ
- 警告ログを追加してデバッグを容易に
- 有効なコンテンツが取得できた記事のみを要約対象に

## Test plan
- [ ] コンテンツ取得に失敗する記事がある場合のテスト
- [ ] 正常にコンテンツが取得できる記事のみがMarkdownファイルに含まれることを確認
- [ ] ログ出力が適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)