### PR TITLE
excerptに要約元記事のリンクを追加

### DIFF
--- a/scripts/fetch_and_summarize.py
+++ b/scripts/fetch_and_summarize.py
@@ -216,17 +216,29 @@ URL: {url}
 短い要約（1-2文）:"""
             
             response = self.model.generate_content(excerpt_prompt)
-            excerpt = response.text.strip()
+            ai_summary = response.text.strip()
             
             # 長すぎる場合は切り詰める
-            if len(excerpt) > 150:
-                excerpt = excerpt[:147] + "..."
+            if len(ai_summary) > 150:
+                ai_summary = ai_summary[:147] + "..."
+            
+            # 要約元記事のタイトルとURLをBullet List形式で追加
+            source_links = []
+            for entry, _ in entries_summaries:
+                source_links.append(f"- [{entry['title']}]({entry['url']})")
+            
+            # AI要約と元記事リンクを結合
+            excerpt = ai_summary + "\n\n" + "\n".join(source_links)
             
             return excerpt
             
         except Exception as e:
             logger.warning(f"Error generating excerpt: {e}")
-            return f"{len(entries_summaries)}件の記事をAIで要約しました"
+            # エラー時でも元記事リンクは表示する
+            source_links = []
+            for entry, _ in entries_summaries:
+                source_links.append(f"- [{entry['title']}]({entry['url']})")
+            return f"{len(entries_summaries)}件の記事をAIで要約しました\n\n" + "\n".join(source_links)
 
     def create_markdown_post(self, entries_summaries, date):
         """Markdown形式のブログ投稿を作成"""

--- a/tests/test_fetch_and_summarize.py
+++ b/tests/test_fetch_and_summarize.py
@@ -219,7 +219,8 @@ class TestHatenaBookmarkSummarizer(unittest.TestCase):
         
         result = self.summarizer.generate_excerpt(entries_summaries)
         
-        self.assertEqual(result, "技術記事とビジネス記事の要約をまとめました。")
+        expected = "技術記事とビジネス記事の要約をまとめました。\n\n- [Tech Article](https://example.com/tech)\n- [Business Article](https://example.com/biz)"
+        self.assertEqual(result, expected)
     
     def test_generate_excerpt_error(self):
         """エクセルプト生成エラーのテスト"""
@@ -232,6 +233,7 @@ class TestHatenaBookmarkSummarizer(unittest.TestCase):
         result = self.summarizer.generate_excerpt(entries_summaries)
         
         self.assertIn("1件の記事をAIで要約しました", result)
+        self.assertIn("- [Article](https://example.com)", result)
     
     def test_create_markdown_post_success(self):
         """Markdownファイル作成成功のテスト"""


### PR DESCRIPTION
## Summary
- ブログ記事のexcerptにAI要約に加えて、要約元記事のタイトルとURLをBullet List形式で追加
- `[リンクテキスト](URL)` 形式でリンクを表示し、読者が元記事に簡単にアクセスできるよう改善
- エラー時でも元記事リンクが表示されるよう対応

## Test plan
- [x] 既存テストをすべて修正し、新しい機能に対応
- [x] Docker環境でテストを実行し、全18テストが成功することを確認
- [x] 正常ケースとエラーケース両方で元記事リンクが正しく表示されることをテスト

🤖 Generated with [Claude Code](https://claude.ai/code)