### PR TITLE
記事カードのアクセシビリティとユーザビリティを向上

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,7 +60,25 @@ main {
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
   border: 1px solid #334155;
-  transition: transform 0.2s ease;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  position: relative;
+}
+
+.post-item:hover {
+  transform: translateY(-2px);
+  background: #334155;
+  border-color: #60a5fa;
+  box-shadow: 0 4px 20px rgba(96, 165, 250, 0.1);
+}
+
+.post-item:focus-within {
+  transform: translateY(-2px);
+  background: #334155;
+  border-color: #60a5fa;
+  box-shadow: 0 4px 20px rgba(96, 165, 250, 0.1);
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
 }
 
 .post-title {
@@ -69,12 +87,11 @@ main {
   margin-bottom: 10px;
 }
 
-.post-title a {
+.post-title {
   color: #f1f5f9;
-  text-decoration: none;
 }
 
-.post-title a:hover {
+.post-item:hover .post-title {
   color: #60a5fa;
 }
 
@@ -105,6 +122,8 @@ main {
 .post-excerpt a {
   color: #60a5fa;
   text-decoration: none;
+  position: relative;
+  z-index: 10;
 }
 
 .post-excerpt a:hover {

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@ layout: default
 <div class="home">
   <div class="post-list">
     {% for post in paginator.posts %}
-      <div class="post-item">
+      <div class="post-item" data-url="{{ post.url | relative_url }}" tabindex="0" role="article" aria-label="{{ post.title }} - 記事を開く">
         <h2 class="post-title">
-          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+          {{ post.title }}
         </h2>
         <div class="post-meta">
           <time datetime="{{ post.date | date_to_xmlschema }}">
@@ -45,3 +45,36 @@ layout: default
     </div>
   {% endif %}
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const postItems = document.querySelectorAll('.post-item');
+  
+  postItems.forEach(function(item) {
+    // クリックイベント
+    item.addEventListener('click', function(e) {
+      // excerpt内のリンクがクリックされた場合は何もしない
+      if (e.target.tagName === 'A' && e.target.closest('.post-excerpt')) {
+        return;
+      }
+      
+      // カード全体がクリックされた場合は記事詳細に遷移
+      const url = this.dataset.url;
+      if (url) {
+        window.location.href = url;
+      }
+    });
+    
+    // キーボードアクセシビリティ対応
+    item.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        const url = this.dataset.url;
+        if (url) {
+          window.location.href = url;
+        }
+      }
+    });
+  });
+});
+</script>


### PR DESCRIPTION
## Summary
- 記事カード全体をクリック可能にし、詳細ページへの遷移を実装
- post-excerpt内のリンクは外部サイトへの遷移を維持
- ホバー時の視覚的フィードバック（背景色変化、ポインタ表示）を追加
- キーボードナビゲーションとスクリーンリーダー対応を実装

## Test plan
- [x] カード全体（タイトル、日付、本文）をクリックして記事詳細ページへ遷移することを確認
- [x] post-excerpt内のリンクをクリックして外部サイトへ遷移することを確認
- [x] ホバー時に背景色が変化し、ポインタが表示されることを確認
- [x] Tabキーでカードにフォーカスし、Enter/Spaceキーで遷移することを確認
- [x] スクリーンリーダーで適切にカードが読み上げられることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)