### PR TITLE
デザインを minimal-blog 準拠のミニマルダークに刷新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ python -m pytest tests/test_fetch_and_summarize.py::TestClass::test_method -v
   `/`, later pages are `/page2/`, `/page3/`, … (the Jekyll `paginate_path` is preserved)
 - **Atom feed**: `src/pages/feed.xml.ts` emits `/feed.xml` in the same Atom format
   jekyll-feed produced, so existing subscribers and the publishing gate keep working
-- **Responsive Design**: Mobile-first CSS with breakpoints at 768px
+- **Responsive Design**: Mobile-first CSS with a breakpoint at 720px
 - **Japanese Localization**: Date formatting and UI text in Japanese
 - **Syntax Highlighting**: Shiki, at build time
 - **Automated Content**: Daily Hatena bookmark summarization using Gemini AI
@@ -139,13 +139,23 @@ python -m pytest tests/test_fetch_and_summarize.py::TestClass::test_method -v
 - Japanese content with proper typography and line-height optimization
 
 ### Styling System
-- **Typography**: Uses Japanese-friendly font stack with Helvetica Neue and Hiragino Sans
-- **Color Palette**:
-  - Background: #0f172a (dark navy)
-  - Card: #1e293b
-  - Accent: #60a5fa (blue)
-- **Components**: Card-based post layout with hover effects and shadows
-- **Responsive**: Mobile-optimized with adjusted padding and font sizes
+The design follows [6uclz1/minimal-blog](https://github.com/6uclz1/minimal-blog), fixed to
+its dark theme. Everything lives in `src/styles/global.css` and is driven by CSS variables
+on `:root` (`--bg` / `--fg` / `--muted` / `--line` / `--panel`, plus the `--content-inline`,
+`--content-max`, `--copy-max` layout widths).
+
+- **Typography**: Japanese-friendly system font stack, light weight (`--text-weight: 300`)
+  with wide letter-spacing on titles
+- **Color Palette**: background #09090b, foreground #f4f4f1, and translucent
+  muted/line/panel tones derived from it — no accent hue
+- **Texture**: a fixed, masked dot pattern (`body::before`) over a subtle radial gradient
+- **Components**: no cards or shadows. The index is a date + title row list
+  (`.post-index` / `.post-row`), the article page is `.post-page` / `.post-body`, and the
+  header is a fixed brand at top-left with the footer at bottom-right
+- **Hover**: links share one effect — a gradient sweeping in from the left that inverts
+  the text color (`--hover-shape` / `--hover-surface`); disabled under
+  `prefers-reduced-motion`
+- **Responsive**: single breakpoint at 720px; the post rows collapse to one column
 
 ## Automation Architecture
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,8 +13,9 @@ export default defineConfig({
   },
   markdown: {
     // Jekyll (Rouge) と同じくビルド時にシンタックスハイライトする
+    // （サイトはダークテーマ固定なので、配色もダーク側に合わせている）
     shikiConfig: {
-      theme: 'github-light',
+      theme: 'github-dark-default',
       wrap: true,
     },
   },

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,8 +4,6 @@ import { SITE } from '../site';
 const year = new Date().getFullYear();
 ---
 
-<footer>
-  <div class="container">
-    <p>&copy; {year} {SITE.title}.</p>
-  </div>
+<footer class="site-footer">
+  <p>&copy; {year} {SITE.title}</p>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,8 +3,6 @@ import { SITE } from '../site';
 import { withBase } from '../lib/posts';
 ---
 
-<header>
-  <div class="container">
-    <a href={withBase('/')} class="site-title">{SITE.title}</a>
-  </div>
+<header class="site-header">
+  <a href={withBase('/')} class="site-header__brand">{SITE.title}</a>
 </header>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -10,25 +10,44 @@ const { currentPage, totalPages } = Astro.props;
 
 // Jekyll の paginate_path: "/page:num/" と同じURLを維持する（1ページ目は "/"）
 const pagePath = (num: number) => withBase(num === 1 ? '/' : `/page${num}/`);
-const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+/**
+ * ミニマルに保つため、先頭・末尾と現在地の前後だけを並べ、
+ * 間は "…" で省略する。
+ */
+const WINDOW = 1;
+const shown = new Set<number>([1, totalPages]);
+for (let num = currentPage - WINDOW; num <= currentPage + WINDOW; num += 1) {
+  if (num >= 1 && num <= totalPages) shown.add(num);
+}
+const numbers = [...shown].sort((a, b) => a - b);
+const items = numbers.flatMap((num, i) =>
+  i > 0 && num - numbers[i - 1] > 1 ? [null, num] : [num]
+);
 ---
 
 {
   totalPages > 1 && (
-    <div class="pagination">
-      {currentPage > 1 && <a href={pagePath(currentPage - 1)}>&laquo; 前へ</a>}
+    <nav class="pagination" aria-label="ページ送り">
+      {currentPage > 1 && <a href={pagePath(currentPage - 1)}>← 前へ</a>}
 
-      {pages.map((num) =>
-        num === currentPage ? (
-          <span class="current">{num}</span>
+      {items.map((num) =>
+        num === null ? (
+          <span class="pagination__gap" aria-hidden="true">
+            …
+          </span>
+        ) : num === currentPage ? (
+          <span class="current" aria-current="page">
+            {num}
+          </span>
         ) : (
           <a href={pagePath(num)}>{num}</a>
         )
       )}
 
       {currentPage < totalPages && (
-        <a href={pagePath(currentPage + 1)}>次へ &raquo;</a>
+        <a href={pagePath(currentPage + 1)}>次へ →</a>
       )}
-    </div>
+    </nav>
   )
 }

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -9,50 +9,31 @@ interface Props {
 const { posts } = Astro.props;
 ---
 
-<div class="post-list">
-  {
-    posts.map((post) => (
-      <div
-        class="post-item"
-        data-url={postUrl(post)}
-        tabindex="0"
-        role="article"
-        aria-label={`${post.data.title} - 記事を開く`}
-      >
-        <h2 class="post-title">{post.data.title}</h2>
-        <div class="post-meta">
-          <time datetime={post.data.date.toISOString()}>
-            {formatDateJa(post.data.date)}
-          </time>
-        </div>
-        {post.data.excerpt && (
-          <div class="post-excerpt" set:html={renderExcerpt(post.data.excerpt)} />
-        )}
-      </div>
-    ))
-  }
-</div>
-
-<script>
-  // カード全体をクリック/Enterで記事に遷移できるようにする
-  document.querySelectorAll<HTMLElement>('.post-item').forEach((item) => {
-    const go = () => {
-      const url = item.dataset.url;
-      if (url) window.location.href = url;
-    };
-
-    item.addEventListener('click', (e) => {
-      // excerpt 内のリンクは本来のリンク先を優先する
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'A' && target.closest('.post-excerpt')) return;
-      go();
-    });
-
-    item.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        go();
-      }
-    });
-  });
-</script>
+{
+  posts.length === 0 ? (
+    <p class="empty-state">記事はまだありません。</p>
+  ) : (
+    <div class="post-index">
+      {posts.map((post) => (
+        <article class="post-row">
+          <span class="post-row__date">
+            <time datetime={post.data.date.toISOString()}>
+              {formatDateJa(post.data.date)}
+            </time>
+          </span>
+          <div class="post-row__body">
+            <a class="post-row__link" href={postUrl(post)}>
+              <span class="post-row__title">{post.data.title}</span>
+            </a>
+            {post.data.excerpt && (
+              <div
+                class="post-row__excerpt"
+                set:html={renderExcerpt(post.data.excerpt)}
+              />
+            )}
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,6 +21,8 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#09090b" />
     <title>{pageTitle}</title>
     <meta name="description" content={description ?? SITE.description} />
     <link rel="canonical" href={canonical} />
@@ -35,10 +37,8 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
   <body>
     <Header />
 
-    <main>
-      <div class="container">
-        <slot />
-      </div>
+    <main class="site-main">
+      <slot />
     </main>
 
     <Footer />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro';
-import { formatDateJa, toDescription } from '../lib/posts';
+import { formatDateJa, toDescription, withBase } from '../lib/posts';
 import { SITE } from '../site';
 
 interface Props {
@@ -14,16 +14,20 @@ const description = excerpt ? toDescription(excerpt) : SITE.description;
 ---
 
 <BaseLayout title={title} description={description}>
-  <article class="post">
-    <header class="post-header">
-      <h1>{title}</h1>
-      <div class="post-meta">
+  <article class="post-page">
+    <header class="post-page__header">
+      <p class="post-page__meta">
         <time datetime={date.toISOString()}>{formatDateJa(date)}</time>
-      </div>
+      </p>
+      <h1>{title}</h1>
     </header>
 
-    <div class="post-content">
+    <div class="post-body">
       <slot />
     </div>
+
+    <nav class="post-nav" aria-label="記事ナビゲーション">
+      <a class="post-nav__back" href={withBase('/')}>← 記事一覧へ</a>
+    </nav>
   </article>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,14 +3,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import PostList from '../components/PostList.astro';
 import Pagination from '../components/Pagination.astro';
 import { getSortedPosts, PAGE_SIZE } from '../lib/posts';
+import { SITE } from '../site';
 
 const posts = await getSortedPosts();
 const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
 ---
 
 <BaseLayout>
-  <div class="home">
+  <section class="page-section">
+    <div class="page-heading">
+      <h1>{SITE.title}</h1>
+      <p class="eyebrow">{SITE.description}</p>
+    </div>
     <PostList posts={posts.slice(0, PAGE_SIZE)} />
     <Pagination currentPage={1} totalPages={totalPages} />
-  </div>
+  </section>
 </BaseLayout>

--- a/src/pages/page[num].astro
+++ b/src/pages/page[num].astro
@@ -5,6 +5,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import PostList from '../components/PostList.astro';
 import Pagination from '../components/Pagination.astro';
 import { getSortedPosts, PAGE_SIZE, type Post } from '../lib/posts';
+import { SITE } from '../site';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getSortedPosts();
@@ -33,8 +34,12 @@ const { posts, currentPage, totalPages } = Astro.props;
 ---
 
 <BaseLayout title={`${currentPage}ページ目`}>
-  <div class="home">
+  <section class="page-section">
+    <div class="page-heading">
+      <h1>{SITE.title}</h1>
+      <p class="eyebrow">{currentPage} / {totalPages} ページ</p>
+    </div>
     <PostList posts={posts} />
     <Pagination currentPage={currentPage} totalPages={totalPages} />
-  </div>
+  </section>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,289 +1,566 @@
-/* Modern Dark Theme Blog CSS */
+/*
+ * Minimal dark theme
+ * 6uclz1/minimal-blog のデザインを踏襲している（ダークテーマ固定）。
+ */
+:root {
+  color-scheme: dark;
+
+  --bg: #09090b;
+  --fg: #f4f4f1;
+  --muted: rgba(244, 244, 241, 0.64);
+  --faint: rgba(244, 244, 241, 0.42);
+  --line: rgba(244, 244, 241, 0.14);
+  --panel: rgba(255, 255, 255, 0.05);
+
+  --bg-rgb: 9 9 11;
+  --fg-rgb: 244 244 241;
+  --noise-rgb: 244 244 241;
+  --readable-text-surface: rgba(var(--bg-rgb) / 0.58);
+
+  --content-inline: 3rem;
+  --content-max: 52rem;
+  --copy-max: 40rem;
+
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+    'Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', YuGothic, Meiryo,
+    sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+
+  --text-weight: 300;
+  --brand-letter-spacing: 0.14em;
+  --brand-hover-trailing-space: 0.44rem;
+  --title-letter-spacing: 0.08em;
+  --title-hover-trailing-space: 0.4rem;
+
+  /* ホバー時に左から流れ込む塗り */
+  --hover-surface: linear-gradient(
+    90deg,
+    var(--readable-text-surface),
+    rgba(var(--bg-rgb) / 0.48)
+  );
+  --hover-shape: linear-gradient(
+    112deg,
+    rgba(var(--fg-rgb) / 0.86) 0 78%,
+    transparent 78% 100%
+  );
+  --hover-inline-space: 0.36rem;
+  --hover-text: #09090b;
+  --link-hover-duration: 900ms;
+  --link-hover-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 * {
-  margin: 0;
-  padding: 0;
   box-sizing: border-box;
 }
 
+html,
 body {
-  font-family: 'Helvetica Neue', 'Hiragino Sans', 'Yu Gothic', sans-serif;
-  line-height: 1.6;
-  color: #e2e8f0;
-  background-color: #0f172a;
+  margin: 0;
+  min-height: 100%;
 }
 
-.container {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 0 20px;
+body {
+  position: relative;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at top left, rgba(127, 127, 127, 0.08), transparent 38%),
+    radial-gradient(circle at bottom right, rgba(127, 127, 127, 0.06), transparent 30%),
+    var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: var(--text-weight);
+  line-height: 1.75;
+}
+
+/* 画面全体に薄くかかるドットのテクスチャ */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: radial-gradient(
+    circle,
+    rgba(var(--noise-rgb) / 0.55) 0,
+    rgba(var(--noise-rgb) / 0.55) 1px,
+    transparent 1px
+  );
+  background-position: 4px 4px;
+  background-size: 8px 8px;
+  -webkit-mask-image:
+    radial-gradient(ellipse at 53% 19%, black 0 18%, transparent 37%),
+    radial-gradient(ellipse at 86% 49%, black 0 18%, transparent 35%),
+    radial-gradient(ellipse at 93% 80%, black 0 8%, transparent 18%),
+    radial-gradient(ellipse at 12% 32%, black 0 16%, transparent 29%);
+  mask-image:
+    radial-gradient(ellipse at 53% 19%, black 0 18%, transparent 37%),
+    radial-gradient(ellipse at 86% 49%, black 0 18%, transparent 35%),
+    radial-gradient(ellipse at 93% 80%, black 0 8%, transparent 18%),
+    radial-gradient(ellipse at 12% 32%, black 0 16%, transparent 29%);
+  opacity: 0.2;
+}
+
+a {
+  color: inherit;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.24em;
+}
+
+.site-header,
+.site-footer,
+.site-main {
+  position: relative;
+  z-index: 1;
 }
 
 /* Header */
-header {
-  background-color: #0f172a;
-  border-bottom: 1px solid #334155;
-  position: sticky;
-  top: 0;
-  z-index: 100;
+.site-header {
+  position: fixed;
+  top: 1.5rem;
+  left: var(--content-inline);
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  max-width: calc(100vw - var(--content-inline) * 2);
+  margin: -0.16rem -0.28rem;
+  padding: 0.42rem 0.52rem;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
-header .container {
-  padding: 20px;
-}
-
-.site-title {
-  font-size: 24px;
-  font-weight: 700;
-  color: #f1f5f9;
+.site-header__brand {
+  max-width: 100%;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: var(--text-weight);
+  letter-spacing: var(--brand-letter-spacing);
+  line-height: 1.35;
   text-decoration: none;
+  white-space: nowrap;
+  transition: color 240ms ease;
 }
 
-.site-title:hover {
-  color: #60a5fa;
+/* Main */
+.site-main {
+  display: grid;
+  align-items: center;
+  min-height: 100vh;
+  padding: 7.5rem var(--content-inline) 5rem;
 }
 
-/* Main Content */
-main {
-  padding: 40px 0;
-  min-height: calc(100vh - 120px);
+.page-section,
+.post-page {
+  width: min(100%, var(--content-max));
+  margin-inline: auto;
 }
 
-/* Post List */
-.post-list {
-  list-style: none;
+.page-section {
+  display: grid;
+  gap: 2.6rem;
 }
 
-.post-item {
-  background: #1e293b;
-  margin-bottom: 30px;
-  padding: 30px;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-  border: 1px solid #334155;
-  transition: all 0.2s ease;
-  cursor: pointer;
-  position: relative;
+.page-heading {
+  display: grid;
+  gap: 0.8rem;
 }
 
-.post-item:hover {
-  transform: translateY(-2px);
-  background: #334155;
-  border-color: #60a5fa;
-  box-shadow: 0 4px 20px rgba(96, 165, 250, 0.1);
+.page-heading h1,
+.post-page__header h1 {
+  margin: 0;
+  color: var(--fg);
+  font-size: 1.72rem;
+  font-weight: var(--text-weight);
+  letter-spacing: var(--title-letter-spacing);
+  line-height: 1.4;
 }
 
-.post-item:focus-within {
-  transform: translateY(-2px);
-  background: #334155;
-  border-color: #60a5fa;
-  box-shadow: 0 4px 20px rgba(96, 165, 250, 0.1);
-  outline: 2px solid #60a5fa;
-  outline-offset: 2px;
+.eyebrow,
+.post-page__meta,
+.post-row__date {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: var(--text-weight);
+  letter-spacing: 0.14em;
+  line-height: 1.35;
 }
 
-.post-title {
-  font-size: 24px;
-  font-weight: 600;
-  margin-bottom: 10px;
+/* Post index */
+.post-index {
+  display: grid;
+  width: 100%;
+  gap: 0.4rem;
 }
 
-.post-title {
-  color: #f1f5f9;
+.post-row {
+  display: grid;
+  grid-template-columns: 9.5rem minmax(0, 1fr);
+  gap: 0.4rem 1.8rem;
+  min-width: 0;
+  border-bottom: 1px solid var(--line);
+  padding: 1.5rem 0;
 }
 
-.post-item:hover .post-title {
-  color: #60a5fa;
+.post-row:last-child {
+  border-bottom: 0;
 }
 
-.post-meta {
-  color: #94a3b8;
-  font-size: 14px;
-  margin-bottom: 8px;
+.post-row__date {
+  padding-top: 0.28rem;
 }
 
-.post-excerpt {
-  color: #cbd5e1;
-  line-height: 1.7;
-  word-break: break-all;
+.post-row__body {
+  display: grid;
+  gap: 0.7rem;
+  min-width: 0;
 }
 
-.post-excerpt ul, .post-excerpt ol {
-  margin: 15px 0;
-  padding-left: 25px;
-  list-style-type: disc;
-}
-
-.post-excerpt li {
-  display: list-item;
-  margin-bottom: 8px;
-  line-height: 1.6;
-}
-
-.post-excerpt a {
-  color: #60a5fa;
+.post-row__link {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  color: var(--muted);
   text-decoration: none;
-  position: relative;
-  z-index: 10;
+  transition: color 240ms ease;
 }
 
-.post-excerpt a:hover {
-  text-decoration: underline;
-}
-
-/* Single Post */
-.post-header {
-  text-align: center;
-  margin-bottom: 40px;
-  border-bottom: 1px solid #334155;
-}
-
-.post-header h1 {
-  font-size: 24px;
-  font-weight: 700;
-  color: #f1f5f9;
-  margin-bottom: 2px;
-  padding-top: 8px;
-}
-
-.post-content {
-  background: #1e293b;
-  padding: 40px;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-  border: 1px solid #334155;
-  word-break: break-all;
-}
-
-.post-content h2 {
-  font-size: 24px;
-  margin: 30px 0 15px;
-  color: #f1f5f9;
-}
-
-.post-content h3 {
-  font-size: 20px;
-  margin: 25px 0 10px;
-  color: #e2e8f0;
-}
-
-.post-content p {
-  margin-bottom: 20px;
-  line-height: 1.8;
-  word-break: break-all;
-}
-
-.post-content ul, .post-content ol {
-  margin: 20px 0;
-  padding-left: 30px;
-}
-
-.post-content li {
-  margin-bottom: 8px;
-}
-
-.post-content blockquote {
-  border-left: 4px solid #60a5fa;
-  padding: 15px 20px;
-  margin: 20px 0;
-  background: #334155;
-  font-style: italic;
-  color: #e2e8f0;
-}
-
-.post-content code {
-  background: #334155;
-  color: #fbbf24;
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-family: 'Monaco', 'Menlo', monospace;
-  font-size: 14px;
-}
-
-.post-content pre {
-  background: #0f172a;
-  color: #e2e8f0;
-  padding: 20px;
-  border-radius: 6px;
-  border: 1px solid #334155;
-  overflow-x: auto;
-  margin: 20px 0;
-}
-
-.post-content pre code {
-  background: none;
-  padding: 0;
+.post-row__title {
   color: inherit;
+  font-size: 1rem;
+  font-weight: var(--text-weight);
+  letter-spacing: var(--title-letter-spacing);
+  line-height: 1.5;
 }
 
-.post-content a {
-  color: #60a5fa;
+.post-row__excerpt {
+  display: grid;
+  gap: 0.5rem;
+  color: var(--faint);
+  font-size: 0.84rem;
+  letter-spacing: 0.02em;
+  line-height: 1.8;
+  overflow-wrap: anywhere;
+}
+
+.post-row__excerpt > * {
+  margin: 0;
+}
+
+.post-row__excerpt ul,
+.post-row__excerpt ol {
+  display: grid;
+  gap: 0.35rem;
+  padding-left: 1.4rem;
+}
+
+.post-row__excerpt a {
+  color: var(--muted);
   text-decoration: none;
+  transition: color 240ms ease;
 }
 
-.post-content a:hover {
+.post-row__excerpt a:hover,
+.post-row__excerpt a:focus-visible {
+  color: var(--fg);
+  outline: none;
   text-decoration: underline;
+}
+
+.empty-state {
+  color: var(--muted);
+}
+
+/* Single post */
+.post-page {
+  display: grid;
+  gap: 1.8rem;
+  max-width: var(--copy-max);
+}
+
+.post-page__header {
+  display: grid;
+  gap: 0.92rem;
+}
+
+.post-page__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.1rem;
+  margin: 0;
+}
+
+.post-body {
+  display: grid;
+  gap: 1.1rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+  letter-spacing: 0.02em;
+  line-height: 1.9;
+  overflow-wrap: anywhere;
+}
+
+.post-body > * {
+  margin: 0;
+}
+
+.post-body h2,
+.post-body h3,
+.post-body h4 {
+  margin-top: 1rem;
+  color: var(--fg);
+  font-weight: var(--text-weight);
+  letter-spacing: 0.08em;
+  line-height: 1.5;
+}
+
+.post-body h2 {
+  font-size: 1.12rem;
+}
+
+.post-body h3 {
+  font-size: 1rem;
+}
+
+.post-body h4 {
+  font-size: 0.94rem;
+}
+
+.post-body ul,
+.post-body ol {
+  display: grid;
+  gap: 0.4rem;
+  padding-left: 1.72rem;
+}
+
+.post-body blockquote {
+  border-left: 1px solid var(--line);
+  background: var(--panel);
+  padding: 1rem 1.1rem;
+}
+
+.post-body blockquote > * {
+  margin: 0;
+}
+
+.post-body code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+}
+
+.post-body :not(pre) > code {
+  background: var(--panel);
+  padding: 0.1em 0.34em;
+}
+
+.post-body pre {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  padding: 1rem 1.1rem;
+  font-size: 0.84rem;
+  line-height: 1.7;
+}
+
+.post-body img {
+  max-width: 100%;
+  height: auto;
+}
+
+.post-body table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.post-body th,
+.post-body td {
+  border-bottom: 1px solid var(--line);
+  padding: 0.55rem 0.4rem;
+  text-align: left;
+}
+
+.post-body a {
+  color: var(--fg);
+  text-decoration: underline;
+}
+
+.post-body hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+/* Post navigation */
+.post-nav {
+  display: grid;
+  gap: 1.8rem;
+  margin-top: 0.8rem;
+}
+
+.post-nav__back {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: var(--text-weight);
+  justify-self: start;
+  letter-spacing: 0.08em;
+  line-height: 1.45;
+  text-decoration: none;
+  transition: color 240ms ease;
 }
 
 /* Pagination */
 .pagination {
-  text-align: center;
-  margin: 40px 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.9rem;
 }
 
-.pagination a, .pagination span {
-  display: inline-block;
-  padding: 8px 16px;
-  margin: 0 4px;
+.pagination a,
+.pagination span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: var(--text-weight);
+  letter-spacing: 0.08em;
+  line-height: 1.45;
   text-decoration: none;
-  border: 1px solid #475569;
-  border-radius: 4px;
-  background: #1e293b;
-}
-
-.pagination a {
-  color: #60a5fa;
-}
-
-.pagination a:hover {
-  background: #60a5fa;
-  color: #0f172a;
-  border-color: #60a5fa;
+  transition: color 240ms ease;
 }
 
 .pagination .current {
-  background: #60a5fa;
-  color: #0f172a;
-  border-color: #60a5fa;
+  color: var(--fg);
+}
+
+.pagination__gap {
+  color: var(--faint);
 }
 
 /* Footer */
-footer {
-  background: #0f172a;
-  border-top: 1px solid #334155;
-  color: #94a3b8;
-  text-align: center;
-  padding: 20px 0;
+.site-footer {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  justify-items: end;
+  padding: 0 var(--content-inline) 1.6rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: var(--text-weight);
+  letter-spacing: 0.08em;
+  line-height: 1.35;
+  text-align: right;
+}
+
+/*
+ * ホバーで左から塗りが流れ込む共通エフェクト。
+ * minimal-blog と同じく、テキスト幅ぴったりの背景として当てている。
+ */
+.site-header__brand,
+.page-heading > *,
+.post-page__header h1,
+.post-page__meta,
+.post-row__title,
+.post-nav__back,
+.pagination a,
+.pagination span,
+.site-footer p,
+.empty-state {
+  width: fit-content;
+  max-width: 100%;
+  margin: -0.16rem -0.28rem;
+  background-image: var(--hover-shape), var(--hover-surface);
+  background-position:
+    -1.2rem 50%,
+    50% 50%;
+  background-repeat: no-repeat;
+  background-size:
+    0% 100%,
+    100% 100%;
+  padding: 0.2rem var(--hover-inline-space);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  transition:
+    color var(--link-hover-duration) var(--link-hover-ease),
+    background-size var(--link-hover-duration) var(--link-hover-ease),
+    background-position var(--link-hover-duration) var(--link-hover-ease);
+}
+
+.site-header__brand {
+  padding-right: calc(
+    var(--hover-inline-space) + var(--brand-letter-spacing) +
+      var(--brand-hover-trailing-space)
+  );
+}
+
+.page-heading h1,
+.post-page__header h1,
+.post-row__title {
+  padding-right: calc(
+    var(--hover-inline-space) + var(--title-letter-spacing) +
+      var(--title-hover-trailing-space)
+  );
+}
+
+.site-header__brand:hover,
+.site-header__brand:focus-visible,
+.post-row__link:hover .post-row__title,
+.post-row__link:focus-visible .post-row__title,
+.post-nav__back:hover,
+.post-nav__back:focus-visible,
+.pagination a:hover,
+.pagination a:focus-visible {
+  background-position:
+    0 50%,
+    50% 50%;
+  background-size:
+    142% 100%,
+    100% 100%;
+  color: var(--hover-text);
+}
+
+.site-header__brand:focus-visible,
+.post-row__link:focus-visible,
+.post-nav__back:focus-visible,
+.pagination a:focus-visible {
+  outline: none;
 }
 
 /* Responsive */
-@media (max-width: 768px) {
-  .container {
-    padding: 0 15px;
+@media (max-width: 720px) {
+  :root {
+    --content-inline: 1.5rem;
   }
-  
-  .post-item {
-    padding: 20px;
+
+  .site-header {
+    top: 1rem;
   }
-  
-  .post-content {
-    padding: 20px;
+
+  .site-main {
+    align-items: start;
+    padding-block: 6rem 4rem;
   }
-  
-  .post-header h1 {
-    font-size: 24px;
+
+  .page-heading h1,
+  .post-page__header h1 {
+    font-size: 1.48rem;
   }
-  
-  .post-title {
-    font-size: 20px;
+
+  .post-row {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .post-row__date {
+    padding-top: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header__brand,
+  .post-row__link,
+  .post-row__title,
+  .post-nav__back,
+  .pagination a,
+  .pagination span {
+    transition: none;
   }
 }


### PR DESCRIPTION
6uclz1/minimal-blog のデザインを踏襲し、ダークテーマのまま
全体をブラッシュアップした。

- global.css を CSS 変数ベースで書き直し（#09090b / #f4f4f1、
  アクセント色なし、ドットテクスチャ、左から流れ込むホバー塗り）
- 一覧をカードから「日付 + タイトル」の行リストに変更。
  カード全体クリックの JS をやめ、タイトルを通常のリンクにした
- 記事ページを .post-page / .post-body 構成に変更し、
  末尾に一覧へ戻るリンクを追加
- ヘッダーを左上固定のブランド表示、フッターを右下寄せに
- ページネーションを先頭・末尾＋現在地前後だけの省略表示に
- Shiki のテーマをダークテーマに合わせて github-dark-default へ

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FsL8ahrugapJqWDvHh71nB