### PR TITLE
記事本文の取得に r.jina.ai を利用してTwitter/Xに対応

### DIFF
--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Run fetch and summarize script in Docker
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # 任意。未設定でも r.jina.ai は匿名で利用できる
+          JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
         run: |
           docker compose run --rm python-scripts sh -c "
             pip install -r requirements.txt &&

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,8 +167,15 @@ between stages:
 1. **RSS Processing**: `fetch_entries()` + `select_bookmarks()` — collects every date an entry
    carries (dc_date, entry-id URL pattern, published_parsed) and keeps the ones matching the
    target day, de-duplicating by URL
-2. **Content Extraction**: `fetch_article_text()` scrapes the article with BeautifulSoup using
-   fallback selectors; returns `None` when nothing usable is found (the entry is then skipped)
+2. **Content Extraction**: `fetch_article_text()` picks between two fetchers and returns `None`
+   when neither yields text (the entry is then skipped):
+   - `fetch_article_text_direct()` scrapes the HTML with BeautifulSoup using fallback selectors
+   - `fetch_article_text_via_jina()` fetches `https://r.jina.ai/<url>` for rendered text
+
+   Twitter/X (`JINA_FIRST_HOSTS`) is JavaScript-rendered and shows a login wall, so direct
+   scraping returns nothing usable — those hosts go through r.jina.ai first and fall back to
+   direct. Every other host is scraped directly first and falls back to r.jina.ai when the
+   result is missing or shorter than `MIN_ARTICLE_TEXT_CHARS` (cookie banners, login prompts).
 3. **AI Summarization**: `GeminiSummarizer.summarize()` asks Gemini for JSON
    (`{"summary": ..., "points": [...]}`) via `response_mime_type: application/json`, and
    `parse_digest()` normalizes/truncates it — prompt wording alone doesn't keep the length stable
@@ -198,6 +205,8 @@ writing it — useful for checking the output length after a prompt change.
 
 ### Environment Variables Required
 - `GEMINI_API_KEY`: Required for AI summarization in GitHub Actions (not needed for tests)
+- `JINA_API_KEY`: Optional. Sent as a bearer token to r.jina.ai to relax its rate limit;
+  the reader works anonymously without it
 
 ## Development Notes
 

--- a/README.md
+++ b/README.md
@@ -167,11 +167,18 @@ python scripts/fetch_and_summarize.py --dry-run
 python scripts/fetch_and_summarize.py --date 2026-07-26 --dry-run
 ```
 
+記事本文は通常HTMLを直接取得して抽出しますが、Twitter/X のようにJavaScriptで描画される
+サイトは本文が取れないため、[r.jina.ai](https://r.jina.ai/) 経由でレンダリング済みの
+テキストを取得します。他のサイトでも本文が取れなかった場合は r.jina.ai にフォールバックします。
+
 ### 環境変数
 
 ```bash
 # Gemini API キー（GitHub Actions用）
 GEMINI_API_KEY=your_api_key_here
+
+# r.jina.ai の API キー（任意。未設定でも動作しますが、設定するとレート制限が緩和されます）
+JINA_API_KEY=your_jina_api_key_here
 ```
 
 ## 🚀 デプロイ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     command: tail -f /dev/null
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
+      # 任意。設定すると r.jina.ai のレート制限が緩和される（未設定でも動作する）
+      - JINA_API_KEY=${JINA_API_KEY:-}
 
 volumes:
   node_modules:

--- a/scripts/fetch_and_summarize.py
+++ b/scripts/fetch_and_summarize.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Iterable, Sequence
+from urllib.parse import urlparse
 
 import feedparser
 import google.generativeai as genai
@@ -39,6 +40,9 @@ JST = pytz.timezone("Asia/Tokyo")
 # 記事本文の取得まわり
 HTTP_TIMEOUT_SEC = 15
 ARTICLE_TEXT_LIMIT = 3000
+# 本文として採用する最低文字数。これを下回るときは取得失敗とみなして
+# r.jina.ai 側の結果を使う（ログイン誘導やCookie同意だけのページ対策）
+MIN_ARTICLE_TEXT_CHARS = 200
 USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
@@ -52,6 +56,19 @@ CONTENT_SELECTORS = (
     ".content",
     "main",
     ".main-content",
+)
+
+# r.jina.ai 経由の取得
+# Twitter/X のようにJavaScriptでレンダリングされるサイトは HTML を直接取っても本文が無いため、
+# レンダリング済みのテキストを返してくれる r.jina.ai を使う。
+JINA_READER_PREFIX = "https://r.jina.ai/"
+JINA_TIMEOUT_SEC = 30
+# 直接取得を試さず、最初から r.jina.ai を使うホスト
+JINA_FIRST_HOSTS = (
+    "twitter.com",
+    "x.com",
+    "mobile.twitter.com",
+    "nitter.net",
 )
 
 # 要約の分量。ここを変えると記事全体のボリュームが変わる
@@ -182,8 +199,20 @@ def select_bookmarks(entries: Iterable, target: date) -> list[Bookmark]:
 # 記事本文
 # --------------------------------------------------------------------------
 
-def fetch_article_text(url: str) -> str | None:
-    """記事のメイン本文を抽出する。取得できなければ None"""
+def _host_of(url: str) -> str:
+    """URLのホスト名を小文字で返す（www. は落とす）"""
+    host = urlparse(url).hostname or ""
+    return host.lower().removeprefix("www.")
+
+
+def prefers_jina(url: str) -> bool:
+    """直接取得を飛ばして r.jina.ai を先に使うべきURLか"""
+    host = _host_of(url)
+    return any(host == known or host.endswith(f".{known}") for known in JINA_FIRST_HOSTS)
+
+
+def fetch_article_text_direct(url: str) -> str | None:
+    """記事のHTMLを直接取得して本文を抽出する。取得できなければ None"""
     try:
         response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=HTTP_TIMEOUT_SEC)
         response.raise_for_status()
@@ -212,6 +241,55 @@ def fetch_article_text(url: str) -> str | None:
     except Exception as e:  # noqa: BLE001 - 1記事の失敗で全体を止めない
         logger.error("Error extracting content from %s: %s", url, e)
         return None
+
+
+def fetch_article_text_via_jina(url: str) -> str | None:
+    """r.jina.ai 経由でレンダリング済みのテキストを取得する。取得できなければ None
+
+    JINA_API_KEY があれば付与する（レート制限が緩くなる）。無くても動く。
+    """
+    reader_url = JINA_READER_PREFIX + url
+    headers = {
+        "User-Agent": USER_AGENT,
+        # Markdownのリンクや画像記法は要約に不要なので、プレーンテキストで受け取る
+        "X-Return-Format": "text",
+    }
+    api_key = os.getenv("JINA_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        response = requests.get(reader_url, headers=headers, timeout=JINA_TIMEOUT_SEC)
+        response.raise_for_status()
+
+        text = re.sub(r"\s+", " ", str(response.text or "")).strip()
+        if not text:
+            logger.warning("No content extracted via r.jina.ai from %s", url)
+            return None
+        return text[:ARTICLE_TEXT_LIMIT]
+
+    except Exception as e:  # noqa: BLE001 - 1記事の失敗で全体を止めない
+        logger.error("Error extracting content via r.jina.ai from %s: %s", url, e)
+        return None
+
+
+def fetch_article_text(url: str) -> str | None:
+    """記事の本文テキストを取得する。取得できなければ None
+
+    通常はHTMLを直接取得して抽出するが、Twitter/X のようにJavaScriptで描画されるサイトは
+    本文が取れない（あるいはログイン誘導だけが取れる）ため、r.jina.ai にフォールバックする。
+    """
+    if prefers_jina(url):
+        logger.info("Using r.jina.ai for %s", url)
+        text = fetch_article_text_via_jina(url)
+        return text if text else fetch_article_text_direct(url)
+
+    text = fetch_article_text_direct(url)
+    if text and len(text) >= MIN_ARTICLE_TEXT_CHARS:
+        return text
+
+    logger.info("Falling back to r.jina.ai for %s", url)
+    return fetch_article_text_via_jina(url) or text
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_fetch_and_summarize.py
+++ b/tests/test_fetch_and_summarize.py
@@ -25,9 +25,12 @@ from scripts.fetch_and_summarize import (  # noqa: E402
     Digest,
     GeminiSummarizer,
     fetch_article_text,
+    fetch_article_text_direct,
+    fetch_article_text_via_jina,
     fetch_entries,
     parse_digest,
     post_path,
+    prefers_jina,
     render_post,
     run,
     select_bookmarks,
@@ -130,17 +133,23 @@ class TestSelectBookmarks(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
 
-class TestFetchArticleText(unittest.TestCase):
+def html_response(body: bytes) -> Mock:
+    return Mock(content=body, apparent_encoding='utf-8')
+
+
+def long_article_html(marker: str = 'main content') -> bytes:
+    filler = ('本文のテキストです。' * 40).encode()
+    return (b'<html><body><article><h1>Test Article</h1><p>This is the '
+            + marker.encode() + b'.</p><p>' + filler + b'</p></article></body></html>')
+
+
+class TestFetchArticleTextDirect(unittest.TestCase):
 
     @patch('scripts.fetch_and_summarize.requests')
     def test_success(self, mock_requests):
-        mock_requests.get.return_value = Mock(
-            content=b'<html><body><article><h1>Test Article</h1>'
-                    b'<p>This is the main content.</p></article></body></html>',
-            apparent_encoding='utf-8',
-        )
+        mock_requests.get.return_value = html_response(long_article_html())
 
-        result = fetch_article_text('https://example.com/test')
+        result = fetch_article_text_direct('https://example.com/test')
 
         self.assertIn('Test Article', result)
         self.assertIn('main content', result)
@@ -150,14 +159,124 @@ class TestFetchArticleText(unittest.TestCase):
     def test_error_returns_none(self, mock_requests):
         mock_requests.get.side_effect = Exception("Request failed")
 
-        self.assertIsNone(fetch_article_text('https://example.com/test'))
+        self.assertIsNone(fetch_article_text_direct('https://example.com/test'))
 
     @patch('scripts.fetch_and_summarize.requests')
     def test_empty_body_returns_none(self, mock_requests):
-        mock_requests.get.return_value = Mock(content=b'<html><body></body></html>',
-                                              apparent_encoding='utf-8')
+        mock_requests.get.return_value = html_response(b'<html><body></body></html>')
 
-        self.assertIsNone(fetch_article_text('https://example.com/test'))
+        self.assertIsNone(fetch_article_text_direct('https://example.com/test'))
+
+
+class TestFetchArticleTextViaJina(unittest.TestCase):
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch('scripts.fetch_and_summarize.requests')
+    def test_prefixes_reader_url_and_returns_text(self, mock_requests):
+        mock_requests.get.return_value = Mock(text='  ツイート本文\n\nです  ')
+
+        result = fetch_article_text_via_jina('https://x.com/user/status/123')
+
+        self.assertEqual(result, 'ツイート本文 です')
+        called_url = mock_requests.get.call_args[0][0]
+        self.assertEqual(called_url, 'https://r.jina.ai/https://x.com/user/status/123')
+        self.assertNotIn('Authorization', mock_requests.get.call_args[1]['headers'])
+
+    @patch.dict(os.environ, {'JINA_API_KEY': 'secret-token'}, clear=True)
+    @patch('scripts.fetch_and_summarize.requests')
+    def test_sends_api_key_when_available(self, mock_requests):
+        mock_requests.get.return_value = Mock(text='本文')
+
+        fetch_article_text_via_jina('https://x.com/user/status/123')
+
+        headers = mock_requests.get.call_args[1]['headers']
+        self.assertEqual(headers['Authorization'], 'Bearer secret-token')
+
+    @patch('scripts.fetch_and_summarize.requests')
+    def test_empty_returns_none(self, mock_requests):
+        mock_requests.get.return_value = Mock(text='   ')
+
+        self.assertIsNone(fetch_article_text_via_jina('https://x.com/user/status/123'))
+
+    @patch('scripts.fetch_and_summarize.requests')
+    def test_error_returns_none(self, mock_requests):
+        mock_requests.get.side_effect = Exception("Request failed")
+
+        self.assertIsNone(fetch_article_text_via_jina('https://x.com/user/status/123'))
+
+
+class TestPrefersJina(unittest.TestCase):
+
+    def test_twitter_and_x_use_jina_first(self):
+        for url in (
+            'https://x.com/user/status/1',
+            'https://twitter.com/user/status/1',
+            'https://mobile.twitter.com/user/status/1',
+            'https://www.x.com/user/status/1',
+        ):
+            self.assertTrue(prefers_jina(url), url)
+
+    def test_other_hosts_do_not(self):
+        for url in ('https://example.com/x.com', 'https://notx.com/a', 'https://example.com/'):
+            self.assertFalse(prefers_jina(url), url)
+
+
+class TestFetchArticleText(unittest.TestCase):
+
+    @patch('scripts.fetch_and_summarize.fetch_article_text_via_jina')
+    @patch('scripts.fetch_and_summarize.fetch_article_text_direct')
+    def test_normal_url_uses_direct_only(self, mock_direct, mock_jina):
+        mock_direct.return_value = 'あ' * 500
+
+        result = fetch_article_text('https://example.com/test')
+
+        self.assertEqual(result, 'あ' * 500)
+        mock_jina.assert_not_called()
+
+    @patch('scripts.fetch_and_summarize.fetch_article_text_via_jina')
+    @patch('scripts.fetch_and_summarize.fetch_article_text_direct')
+    def test_falls_back_to_jina_when_direct_fails(self, mock_direct, mock_jina):
+        mock_direct.return_value = None
+        mock_jina.return_value = 'r.jina.ai の本文'
+
+        self.assertEqual(fetch_article_text('https://example.com/test'), 'r.jina.ai の本文')
+        mock_jina.assert_called_once_with('https://example.com/test')
+
+    @patch('scripts.fetch_and_summarize.fetch_article_text_via_jina')
+    @patch('scripts.fetch_and_summarize.fetch_article_text_direct')
+    def test_falls_back_to_jina_when_direct_is_too_short(self, mock_direct, mock_jina):
+        mock_direct.return_value = 'ログインしてください'
+        mock_jina.return_value = 'r.jina.ai の本文'
+
+        self.assertEqual(fetch_article_text('https://example.com/test'), 'r.jina.ai の本文')
+
+    @patch('scripts.fetch_and_summarize.fetch_article_text_via_jina')
+    @patch('scripts.fetch_and_summarize.fetch_article_text_direct')
+    def test_keeps_short_direct_text_when_jina_fails(self, mock_direct, mock_jina):
+        mock_direct.return_value = '短い本文'
+        mock_jina.return_value = None
+
+        self.assertEqual(fetch_article_text('https://example.com/test'), '短い本文')
+
+    @patch('scripts.fetch_and_summarize.fetch_article_text_via_jina')
+    @patch('scripts.fetch_and_summarize.fetch_article_text_direct')
+    def test_twitter_uses_jina_first(self, mock_direct, mock_jina):
+        mock_jina.return_value = 'ツイート本文'
+
+        result = fetch_article_text('https://x.com/user/status/123')
+
+        self.assertEqual(result, 'ツイート本文')
+        mock_direct.assert_not_called()
+
+    @patch('scripts.fetch_and_summarize.fetch_article_text_via_jina')
+    @patch('scripts.fetch_and_summarize.fetch_article_text_direct')
+    def test_twitter_falls_back_to_direct(self, mock_direct, mock_jina):
+        mock_jina.return_value = None
+        mock_direct.return_value = 'HTMLから取れた本文'
+
+        result = fetch_article_text('https://x.com/user/status/123')
+
+        self.assertEqual(result, 'HTMLから取れた本文')
 
 
 class TestParseDigest(unittest.TestCase):


### PR DESCRIPTION
Twitter/X はJavaScriptで描画されログイン誘導が返るため、HTMLを直接取得しても
本文が抽出できず、まとめ記事から常にスキップされていた。

- fetch_article_text() を直接取得(fetch_article_text_direct)と
  r.jina.ai 経由(fetch_article_text_via_jina)の振り分けに変更
- Twitter/X 系ホストは r.jina.ai を先に試し、失敗時のみ直接取得へ
- その他のホストは直接取得を優先し、本文が無い/極端に短い場合に
  r.jina.ai へフォールバック
- JINA_API_KEY があればBearerトークンとして送る（任意）

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G8uEBWApfLtrHty75RMxxQ