### PR TITLE
Slackで一覧が読めるようフィードのsummaryを記事タイトル一覧にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,14 @@ python -m pytest tests/test_fetch_and_summarize.py::TestClass::test_method -v
 - **Pagination**: 10 posts per page with Japanese navigation ("前へ"/"次へ"); page 1 is
   `/`, later pages are `/page2/`, `/page3/`, … (the Jekyll `paginate_path` is preserved)
 - **Atom feed**: `src/pages/feed.xml.ts` emits `/feed.xml` in the same Atom format
-  jekyll-feed produced, so existing subscribers and the publishing gate keep working
+  jekyll-feed produced, so existing subscribers and the publishing gate keep working.
+  Each entry's `<summary>` is built by `src/lib/feed.ts` from the bookmark headings in the
+  post body — a `・`-prefixed title list, nothing else. Slack's RSS integration shows only
+  the head of the summary, so any preamble would push the list out of the preview; the list
+  is capped by `FEED_SUMMARY_MAX_CHARS` / `FEED_SUMMARY_TITLE_MAX_CHARS` and the overflow
+  collapses into `ほかN件`. Lines are separated by both `<br />` and a real newline so
+  HTML readers and tag-stripping clients (Slack) both break lines. Posts without bookmark
+  headings fall back to `excerpt`
 - **Responsive Design**: Mobile-first CSS with a breakpoint at 720px
 - **Japanese Localization**: Date formatting and UI text in Japanese
 - **Syntax Highlighting**: Shiki, at build time

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,0 +1,89 @@
+/**
+ * feed.xml の summary を組み立てる。
+ *
+ * Slack の RSS 連携は entry の summary の「冒頭」だけを本文として表示し、
+ * 長い場合は途中で切り捨てる。前置き（「はてなブックマークで気になった記事を…」）を
+ * 先頭に置くと、肝心のブックマーク一覧が切られて見えなくなるため、
+ * summary は本文中の見出しから拾ったブックマークのタイトル一覧だけで構成する。
+ */
+
+/** Slackのプレビューに収まる範囲。超える分は「ほかN件」にまとめる */
+export const FEED_SUMMARY_MAX_CHARS = 280;
+/** 1件のタイトルがこれを超えたら省略する（1行に収めて一覧の見通しを保つ） */
+export const FEED_SUMMARY_TITLE_MAX_CHARS = 48;
+
+const BULLET = '・';
+
+// ブックマークの見出しだけを拾う。`## 要点` `## 詳細な要約` のような
+// 記事内のセクション見出しを拾わないよう、リンク形式か採番形式のみを対象にする。
+const HEADING_PATTERNS = [
+  // 現在の形式: ## [タイトル](https://example.com/)
+  /^##\s+\[(.+)\]\(https?:\/\/[^)]+\)\s*$/,
+  // 旧形式: ## 1. タイトル
+  /^##\s+\d+\.\s+(.+?)\s*$/,
+];
+
+const collapse = (text: string) => text.replace(/\s+/g, ' ').trim();
+
+/** 記事本文からブックマークのタイトルを出現順に取り出す */
+export function extractBookmarkTitles(body: string): string[] {
+  const titles: string[] = [];
+
+  for (const line of body.split('\n')) {
+    for (const pattern of HEADING_PATTERNS) {
+      const match = pattern.exec(line);
+      if (!match) continue;
+      // 強調記法やバッククォートは一覧では読みにくいので落とす
+      const title = collapse(match[1]!.replace(/[*_`]/g, ''));
+      if (title) titles.push(title);
+      break;
+    }
+  }
+
+  return titles;
+}
+
+function shorten(title: string, limit: number): string {
+  return title.length > limit ? `${title.slice(0, limit - 1).trimEnd()}…` : title;
+}
+
+/**
+ * ブックマーク一覧を summary 用の行に整形する。
+ * 文字数の上限に収まらない分は末尾の「ほかN件」にまとめる。
+ */
+export function buildBookmarkLines(
+  titles: string[],
+  maxChars = FEED_SUMMARY_MAX_CHARS,
+  titleMaxChars = FEED_SUMMARY_TITLE_MAX_CHARS
+): string[] {
+  const lines: string[] = [];
+  let used = 0;
+
+  for (const title of titles) {
+    const line = BULLET + shorten(title, titleMaxChars);
+    const rest = titles.length - lines.length;
+    // 残りを「ほかN件」に畳んだときの長さ。これを足しても収まる場合だけ1行増やす
+    const tail = rest > 1 ? `ほか${rest - 1}件`.length + 1 : 0;
+    if (lines.length > 0 && used + line.length + 1 + tail > maxChars) break;
+
+    lines.push(line);
+    used += line.length + 1;
+  }
+
+  const remaining = titles.length - lines.length;
+  if (remaining > 0) lines.push(`ほか${remaining}件`);
+
+  return lines;
+}
+
+/**
+ * feed の summary 本文（プレーンテキストの行）を返す。
+ * ブックマーク記事でなければ excerpt をそのまま1行として使う。
+ */
+export function feedSummaryLines(body: string, excerpt?: string): string[] {
+  const titles = extractBookmarkTitles(body);
+  if (titles.length > 0) return buildBookmarkLines(titles);
+
+  const fallback = collapse(excerpt ?? '');
+  return fallback ? [fallback] : [];
+}

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { feedSummaryLines } from '../lib/feed';
 import { getSortedPosts, permalinkToParam, type Post } from '../lib/posts';
 import { SITE } from '../site';
 
@@ -29,9 +30,17 @@ export const GET: APIRoute = async ({ site }) => {
     ? posts[0]!.data.date.toISOString()
     : new Date(0).toISOString();
 
+  // Slack などHTMLを落として表示するクライアントでも行が潰れないよう、
+  // <br /> と実際の改行の両方を入れる。
+  // type="html" の中身はHTMLなので、タイトルはHTML用とXML用に二重にエスケープし
+  // （`<Suspense>` のような文字列がタグとして消えないようにする）、<br /> はXMLのみ。
+  const summaryHtml = (lines: string[]) =>
+    lines.map((line) => escapeXml(escapeXml(line))).join('&lt;br /&gt;\n');
+
   const entry = (post: Post) => {
     const url = absoluteUrl(baseUrl, `${permalinkToParam(post.data.permalink)}/`);
     const published = post.data.date.toISOString();
+    const summary = feedSummaryLines(post.body ?? '', post.data.excerpt);
     return `  <entry>
     <title type="html">${escapeXml(post.data.title)}</title>
     <link href="${escapeXml(url)}" rel="alternate" type="text/html" title="${escapeXml(post.data.title)}"/>
@@ -39,8 +48,8 @@ export const GET: APIRoute = async ({ site }) => {
     <updated>${published}</updated>
     <id>${escapeXml(url)}</id>
     <author><name>${escapeXml(SITE.author)}</name></author>${
-      post.data.excerpt
-        ? `\n    <summary type="html">${escapeXml(post.data.excerpt)}</summary>`
+      summary.length
+        ? `\n    <summary type="html">${summaryHtml(summary)}</summary>`
         : ''
     }
   </entry>`;


### PR DESCRIPTION
Slack の RSS 連携は entry の summary の冒頭しか表示しないため、
前置きの1文だけの excerpt では何をブックマークしたのか分からなかった。

summary を記事本文の見出しから作ったブックマークのタイトル一覧に置き換え、
プレビューに収まる文字数で切って残りを「ほかN件」に畳む。
行区切りは <br /> と改行の両方を入れ、HTMLを落とすクライアントでも
1行ずつ表示されるようにした。ブックマーク記事以外は従来どおり excerpt を使う。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LRyGFP7XQi31AbrPrugVk8