### PR TITLE
自動生成した記事が公開されない問題を直す

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,16 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # 自動更新ワークフローから呼び出すための入口。
+  # GITHUB_TOKEN による push は他のワークフローを起動しない（再帰実行の防止）ので、
+  # 上の push トリガーでは自動生成された記事が永久に公開されない
+  workflow_call:
+    inputs:
+      ref:
+        description: 'ビルドするコミット。未指定ならイベント既定のref'
+        required: false
+        type: string
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -29,6 +39,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # 呼び出し元は push したばかりのコミットを渡す。
+          # push / workflow_dispatch では空になり、既定のrefが使われる
+          ref: ${{ inputs.ref }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -18,6 +18,9 @@ jobs:
   update-blog:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      pushed: ${{ steps.commit.outputs.pushed }}
+      sha: ${{ steps.commit.outputs.sha }}
 
     steps:
       - name: Checkout repository
@@ -92,9 +95,11 @@ jobs:
           if-no-files-found: ignore
 
       # 検証を通ったのでコミットして push する。
-      # 公開は push を受けた deploy.yml に任せる。両方から Pages にデプロイすると
-      # 同じ environment に対する同時デプロイになり、片方が失敗する
+      # 公開はこの後の deploy ジョブ（deploy.yml の呼び出し）に任せる。
+      # GITHUB_TOKEN による push は deploy.yml の push トリガーを起動しないため、
+      # ここから明示的に呼ばないと記事はコミットされたまま公開されない
       - name: Commit and push changes
+        id: commit
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
           git config --local user.email "action@github.com"
@@ -106,6 +111,8 @@ jobs:
           # rebase しながら数回まで再試行する
           for attempt in 1 2 3 4; do
             if git push origin HEAD:main; then
+              echo "pushed=true" >> $GITHUB_OUTPUT
+              echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
               exit 0
             fi
             echo "push に失敗しました (試行 ${attempt}/4)。rebase して再試行します"
@@ -137,5 +144,48 @@ jobs:
             gh issue comment "$existing" --body "$body"
           else
             gh issue create --title "自動更新ワークフローが失敗しました" \
+              --label automation-failure --body "$body"
+          fi
+
+  # push しただけでは公開されないので、ここから Pages へのデプロイを呼ぶ。
+  # deploy.yml 側の push トリガーはこの push では起動しない
+  deploy:
+    needs: update-blog
+    if: needs.update-blog.outputs.pushed == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ref: ${{ needs.update-blog.outputs.sha }}
+
+  # 記事はコミット済みなのに公開だけ落ちた状態に気づけるようにする
+  report-deploy-failure:
+    needs: deploy
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Report failure as issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create automation-failure --color B60205 \
+            --description "自動更新ワークフローの失敗" 2>/dev/null || true
+
+          body="自動生成した記事のコミットは成功しましたが、GitHub Pages への公開に失敗しました。main には記事があるのにサイトに出ていない状態です。
+
+          - 実行ログ: ${RUN_URL}
+
+          再実行する場合は Actions から \`Deploy Astro site to Pages\` を workflow_dispatch してください。"
+
+          existing=$(gh issue list --label automation-failure --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "自動更新した記事の公開に失敗しました" \
               --label automation-failure --body "$body"
           fi

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -24,6 +24,9 @@ jobs:
   weekly-digest:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      pushed: ${{ steps.commit.outputs.pushed }}
+      sha: ${{ steps.commit.outputs.sha }}
 
     steps:
       - name: Checkout repository
@@ -95,8 +98,11 @@ jobs:
             _posts/
           if-no-files-found: ignore
 
-      # 検証を通ったのでコミットして push する。公開は deploy.yml に任せる
+      # 検証を通ったのでコミットして push する。
+      # GITHUB_TOKEN による push は deploy.yml の push トリガーを起動しないので、
+      # 公開はこの後の deploy ジョブから明示的に呼ぶ
       - name: Commit and push changes
+        id: commit
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
           git config --local user.email "action@github.com"
@@ -108,6 +114,8 @@ jobs:
           # rebase しながら数回まで再試行する
           for attempt in 1 2 3 4; do
             if git push origin HEAD:main; then
+              echo "pushed=true" >> $GITHUB_OUTPUT
+              echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
               exit 0
             fi
             echo "push に失敗しました (試行 ${attempt}/4)。rebase して再試行します"
@@ -139,5 +147,47 @@ jobs:
             gh issue comment "$existing" --body "$body"
           else
             gh issue create --title "週刊まとめの生成が失敗しました" \
+              --label automation-failure --body "$body"
+          fi
+
+  # push しただけでは公開されないので、ここから Pages へのデプロイを呼ぶ
+  deploy:
+    needs: weekly-digest
+    if: needs.weekly-digest.outputs.pushed == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ref: ${{ needs.weekly-digest.outputs.sha }}
+
+  # 記事はコミット済みなのに公開だけ落ちた状態に気づけるようにする
+  report-deploy-failure:
+    needs: deploy
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Report failure as issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create automation-failure --color B60205 \
+            --description "自動更新ワークフローの失敗" 2>/dev/null || true
+
+          body="週刊まとめのコミットは成功しましたが、GitHub Pages への公開に失敗しました。
+
+          - 実行ログ: ${RUN_URL}
+
+          再実行する場合は Actions から \`Deploy Astro site to Pages\` を workflow_dispatch してください。"
+
+          existing=$(gh issue list --label automation-failure --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "週刊まとめの公開に失敗しました" \
               --label automation-failure --body "$body"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,10 +242,15 @@ between stages:
    of them — both the current `## [title](url)` form and the legacy `## 1. title` +
    `**URL:**` form that every existing post uses — and writes one look-back post. It never
    calls Gemini: the summaries already exist in the daily posts
-6. **Deployment**: `update-blog.yml` commits and pushes the post; the push triggers
-   `deploy.yml`, which builds with Astro, runs the publishing gate, and deploys to GitHub
-   Pages. Only `deploy.yml` deploys — deploying from both races on the `github-pages`
-   environment
+6. **Deployment**: `update-blog.yml` commits and pushes the post, then calls `deploy.yml`
+   as a reusable workflow (`workflow_call`) with the pushed commit as `ref`. `deploy.yml`
+   builds with Astro, runs the publishing gate, and deploys to GitHub Pages, and it is the
+   only place that deploys — deploying from two workflows races on the `github-pages`
+   environment. The call is not optional: a push made with `GITHUB_TOKEN` never triggers
+   another workflow (GitHub's recursion guard), so `deploy.yml`'s `push` trigger does not
+   fire for automated posts and the article would sit on `main` unpublished.
+   `weekly-digest.yml` does the same. A deploy that fails after the commit landed opens an
+   issue from the `report-deploy-failure` job
 
 **Post length is a product decision**: the daily digest is meant to be skimmed in the morning, so
 the summary length limits live in the script (`SUMMARY_MAX_CHARS`, `POINT_MAX_CHARS`, `MAX_POINTS`)

--- a/README.md
+++ b/README.md
@@ -243,8 +243,12 @@ GitHub Pagesを使用した自動デプロイが設定されています：
 3. `scripts/validate_build.py` による公開前検証
 4. GitHub Pagesへの自動デプロイ
 
-自動更新ワークフロー（`update-blog.yml`）は記事をコミットして push するところまでを担当し、
-公開はその push を受けた `deploy.yml` が行います（Pages への同時デプロイを避けるため）。
+自動更新ワークフロー（`update-blog.yml` / `weekly-digest.yml`）は記事をコミットして push した
+あと、`deploy.yml` を再利用ワークフロー（`workflow_call`）として呼び出して公開します。
+デプロイを行うのは `deploy.yml` だけです（Pages への同時デプロイを避けるため）。
+
+`GITHUB_TOKEN` による push は他のワークフローを起動しない仕様なので、`deploy.yml` の push
+トリガーは自動生成された記事では発火しません。そのため呼び出しは省略できません。
 
 ## 🎨 カスタマイズ
 


### PR DESCRIPTION
## 何が起きていたか

指定いただいた [run 30315754287](https://github.com/6uclz1/claude-code-blog-site/actions/runs/30315754287) 自体は**成功**しています（全14ステップ success、7件の記事 `_posts/2026-07-27-hatena-bookmarks.md` を生成して `5700af2` を main に push 済み）。

失敗していたのはその**後**です。`update-blog.yml` は「push すれば `deploy.yml` の push トリガーが発火して公開される」前提でしたが、`GITHUB_TOKEN` を使った push は他のワークフローを起動しません（GitHub の再帰実行防止）。そのため `deploy.yml` は一度も起動せず、記事は main にあるのにサイトには 0 件のまま反映されませんでした。

`deploy.yml` の実行履歴を確認したところ、`自動更新: …` というボットのコミットで起動した run は過去に一件もありません（全て人手の push 由来）。#39 で `update-blog.yml` 側の自前デプロイを外した時点からの回帰で、今回の日次実行が最初の被害です。

## 修正内容

- `deploy.yml` に `workflow_call`（`ref` 入力つき）を追加して再利用ワークフロー化。`ref` は push / workflow_dispatch では空になり、従来どおり既定の ref をチェックアウトします
- `update-blog.yml` / `weekly-digest.yml` の commit ステップに `id: commit` と `pushed` / `sha` 出力を追加し、push が成功したときだけ `deploy.yml` を呼ぶ `deploy` ジョブを追加。push したコミットそのものを `ref` として渡すので、並行 push があっても検証済みのツリーが公開されます
- デプロイするのは引き続き `deploy.yml` だけなので、`github-pages` environment への同時デプロイは起きません
- 記事のコミットは通ったのに公開だけ落ちた状態を無人で検知できるよう、`report-deploy-failure` ジョブを追加（既存の `automation-failure` ラベル運用に合わせています）
- `CLAUDE.md` / `README.md` の記述を実装に合わせて更新

## 検証

- 3ワークフローの YAML パースとジョブグラフを確認済み
- Python テストはこの環境では `sgmllib3k` のビルドが失敗して実行できませんでしたが、変更はワークフロー YAML とドキュメントのみでスクリプトには触れていません

## 補足（この PR の対象外）

- 未マージの Dependabot PR（typescript ^7.0.2）の Run Tests が `npm ci` の peer 競合で落ちています。`@astrojs/check@0.9.10` が `typescript@^5 || ^6` しか受け付けないためで、`@astrojs/check` 側が TS7 に対応するまでマージできません
- マージ後、この PR の push で `deploy.yml` が走るので、未公開だった 7/27 の記事もそのタイミングで公開されます

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpzyfYVEqAWmwrHmpLbTiZ)_