### PR TITLE
CI/CD の改善: Action・Node更新、カバレッジのPRコメント、異常検知、共通セットアップ

### DIFF
--- a/.github/actions/report-failure/action.yml
+++ b/.github/actions/report-failure/action.yml
@@ -1,0 +1,55 @@
+# 無人運用なので、失敗に気づく手段は issue しかない。
+# 同じ内容の shell が4か所に写経されていたのでここにまとめた。
+#
+# 同じラベルの open な issue があれば新規に立てずコメントを足す。
+# 毎日失敗すると issue が積み上がって、どれが今の話か分からなくなるため。
+name: Report failure as issue
+description: 失敗を issue に記録する（同じラベルの open な issue があればコメントを追記）
+
+inputs:
+  title:
+    description: 新しく立てる issue のタイトル
+    required: true
+  body:
+    description: issue の本文
+    required: true
+  label:
+    description: issue のラベル。同じラベルの open な issue を探して再利用する
+    required: false
+    default: automation-failure
+  label-color:
+    description: ラベルを作るときの色
+    required: false
+    default: B60205
+  token:
+    description: 'gh が使うトークン（issues: write の権限が必要）'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Create or update issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        ISSUE_TITLE: ${{ inputs.title }}
+        ISSUE_BODY: ${{ inputs.body }}
+        ISSUE_LABEL: ${{ inputs.label }}
+        LABEL_COLOR: ${{ inputs.label-color }}
+      run: |
+        set -euo pipefail
+
+        # ラベルが無い状態で --label を渡すと gh が落ちるので、先に作っておく
+        gh label create "$ISSUE_LABEL" --color "$LABEL_COLOR" \
+          --description "自動化ワークフローの失敗" 2>/dev/null || true
+
+        existing=$(gh issue list --label "$ISSUE_LABEL" --state open --limit 1 \
+          --json number --jq '.[0].number // empty')
+
+        if [ -n "$existing" ]; then
+          gh issue comment "$existing" --body "$ISSUE_BODY"
+          echo "既存の issue #${existing} にコメントしました"
+        else
+          gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" --body "$ISSUE_BODY"
+        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,9 @@ inputs:
   node-version:
     description: 使う Node のバージョン
     required: false
-    default: '22'
+    # Active LTS。22 は Maintenance LTS に落ちている。
+    # Dockerfile / Dockerfile.production の node:24-slim と合わせること
+    default: '24'
 
 runs:
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,24 @@
+# 4つのワークフローが同じ Node のセットアップを繰り返していたので1か所にまとめた。
+# Node のバージョンを上げるときはここだけ直せばよい。
+name: Setup Node project
+description: Node のセットアップと依存関係のインストール（npm ci）
+
+inputs:
+  node-version:
+    description: 使う Node のバージョン
+    required: false
+    default: '22'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    # npm ci は package-lock.json どおりに入れ直す（install と違って lock を書き換えない）
+    - name: Install dependencies
+      shell: bash
+      run: npm ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,35 @@
 version: 2
 
 # 無人で毎日動くリポジトリなので、依存の更新漏れに気づけるようにする。
-# 特に requirements.txt は pin が古いまま放置され、SDKの仕様変更に
-# 気づけない状態になっていた。
+# Action は放置すると非推奨のまま動かなくなるので、月次より短い間隔で拾う。
+# （Python は TypeScript に移行済みなので pip の監視は外した）
 updates:
   - package-ecosystem: github-actions
+    # / を指定すると .github/workflows と .github/actions の両方を見る
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     commit-message:
       prefix: 'ci'
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: monthly
-    commit-message:
-      prefix: 'deps'
+    groups:
+      # 公式 Action はまとめて1本のPRにする。個別に来ても確認することは同じ
+      actions:
+        patterns:
+          - 'actions/*'
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     commit-message:
       prefix: 'deps'
+    groups:
+      # パッチ/マイナーはまとめる。メジャーは壊れ方が読めないので個別に見る
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,40 +38,43 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # 呼び出し元は push したばかりのコミットを渡す。
           # push / workflow_dispatch では空になり、既定のrefが使われる
           ref: ${{ inputs.ref }}
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
+
+      # Node のセットアップは .github/actions/setup に集約している
+      - name: Setup
+        uses: ./.github/actions/setup
+
       - name: Build with Astro
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run build 2>&1 | tee build.log
+
       # ビルドが成功しても記事が壊れたまま公開されることがあるため、
       # ビルドログと feed.xml を検査してから公開する
       - name: Validate build output
         run: |
           npm run validate -- --log build.log --feed dist/feed.xml \
             --dist dist --min-entries 1
+
       - name: Upload build log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astro-build-log
           path: build.log
           if-no-files-found: ignore
+          retention-days: 14
+
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
@@ -86,4 +89,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,87 @@
+# 公開中のサイトの異常検知。
+#
+# 既存のワークフローは「実行されたときに失敗したら気づく」形なので、
+# cron が止まった・ブックマークが0件で毎日空振りしている・デプロイが古い成果物を
+# 出し続けている、といった「何も起きない」壊れ方には気づけない。
+# ここでは実際に公開されている feed.xml を外から見て、更新が止まっていないかを確かめる。
+name: Site Health Check
+
+on:
+  # 日次記事は 8:00 JST に作られる。その2時間後に確認する
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      max_age_hours:
+        description: '最新記事の許容される古さ（時間）'
+        required: false
+        default: '36'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: health-check
+  cancel-in-progress: false
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Check published site
+        id: check
+        env:
+          FEED_URL: https://6uclz1.github.io/claude-code-blog-site/feed.xml
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '36' }}
+        run: |
+          set -euo pipefail
+          # --silent で npm 自身のエラー出力を抑える。
+          # そうしないとスクリプトの指摘が npm ERR! に埋もれて issue に載らない
+          npm run --silent health-check -- \
+            --feed "$FEED_URL" \
+            --max-age-hours "$MAX_AGE_HOURS" \
+            --min-entries 1 2>&1 | tee health-check.log
+
+      - name: Read check output
+        if: failure()
+        id: output
+        run: |
+          set -euo pipefail
+          {
+            echo 'log<<HEALTH_EOF'
+            tail -n 40 health-check.log 2>/dev/null || echo '(出力なし)'
+            echo 'HEALTH_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # 更新が止まっているのは自動化の失敗と同じなので、同じラベルにまとめる
+      - name: Report as issue
+        if: failure()
+        uses: ./.github/actions/report-failure
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 公開中のサイトに異常があります
+          label: site-health
+          label-color: D93F0B
+          body: |
+            公開されている feed.xml の検査に失敗しました。ワークフローは緑のまま
+            更新が止まっている可能性があります。
+
+            ```
+            ${{ steps.output.outputs.log }}
+            ```
+
+            - 実行ログ: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            確認する順番:
+            1. `Update Blog with Hatena Bookmarks` の直近の実行が成功しているか
+            2. 成功しているのに記事が増えていないなら、はてなブックマークが0件だった可能性
+            3. `_posts/` に記事があるのにサイトに出ていないなら `Deploy Astro site to Pages` を再実行

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,21 @@ on:
   # ここで走らせると同じ内容を二重にビルドすることになる
   workflow_dispatch:
 
+permissions:
+  contents: read
+  # カバレッジをプルリクにコメントするために必要
+  pull-requests: write
+
+# 同じPRに続けて push したとき、古い実行を走らせ続けても結果は捨てられる
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # 下回ったらプルリクを失敗させる行カバレッジ。
+  # 現状(約89%)から少し余裕を持たせた値。上げるときはこの1行だけ直す
+  MIN_LINE_COVERAGE: '85'
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,16 +29,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      # Node のセットアップは .github/actions/setup に集約している
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Type check
         run: npm run check
@@ -32,9 +42,75 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
+      # しきい値割れでもコメントは出したいので、ここでは失敗させずに終了コードを持ち回る。
+      # 判定は最後の "Enforce coverage threshold" で行う
+      - name: Build coverage report
+        id: coverage
+        if: always()
+        run: |
+          set +e
+          npm run coverage-report -- \
+            --summary coverage/coverage-summary.json \
+            --out coverage-comment.md \
+            --min-lines "${MIN_LINE_COVERAGE}" \
+            --run-url "${RUN_URL}"
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          # フォークからのPRなどコメントできない場合でも数字が見えるようにする
+          if [ -f coverage-comment.md ]; then
+            cat coverage-comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      # フォークからのPRでは GITHUB_TOKEN が読み取り専用で、コメントすると失敗する
+      - name: Comment coverage on pull request
+        if: >-
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          hashFiles('coverage-comment.md') != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { readFile } = await import('node:fs/promises');
+            const body = await readFile('coverage-comment.md', 'utf8');
+            const marker = '<!-- coverage-report -->';
+
+            // 実行のたびに新しいコメントを足すと流れが埋まるので、目印で探して更新する
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      # 終了コード 1 がしきい値割れ。2 は「カバレッジを読めなかった」で、
+      # その場合はテスト自体が落ちているのでここで重ねて騒がない
+      - name: Enforce coverage threshold
+        if: always() && steps.coverage.outputs.exit_code == '1'
+        run: |
+          echo "::error::行カバレッジが ${MIN_LINE_COVERAGE}% を下回りました（詳細はPRのコメントを参照）"
+          exit 1
+
       - name: Build with Astro
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run build 2>&1 | tee build.log
 
       # ビルドが成功しても記事が壊れたままマージされることがあるため、
@@ -45,8 +121,26 @@ jobs:
 
       - name: Upload build log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astro-build-log
           path: build.log
           if-no-files-found: ignore
+          retention-days: 14
+
+  # ワークフロー自体の壊れ（存在しないキー、式の書き間違い、shellcheck 相当の指摘）は
+  # 実行してみるまで気づけないので、静的に検査する
+  lint-workflows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Run actionlint
+        run: |
+          set -euo pipefail
+          docker run --rm -v "${PWD}:/repo" --workdir /repo \
+            rhysd/actionlint:1.7.12 -color

--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -24,16 +24,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      # Node のセットアップは .github/actions/setup に集約している
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run fetch and summarize script
         env:
@@ -45,10 +40,11 @@ jobs:
       - name: Check for changes
         id: verify-changed-files
         run: |
+          set -euo pipefail
           if [ -n "$(git status --porcelain _posts/)" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       # ここから公開前ゲート: 検証を通らなかったものはコミットしない
@@ -59,7 +55,7 @@ jobs:
       - name: Build Astro site
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run build 2>&1 | tee build.log
 
       # ビルドが成功しても記事が壊れたまま公開されることがあるため、
@@ -72,13 +68,14 @@ jobs:
 
       - name: Upload build output on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failed-build
           path: |
             build.log
             _posts/
           if-no-files-found: ignore
+          retention-days: 14
 
       # 検証を通ったのでコミットして push する。
       # 公開はこの後の deploy ジョブ（deploy.yml の呼び出し）に任せる。
@@ -88,6 +85,7 @@ jobs:
         id: commit
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
+          set -euo pipefail
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add _posts/
@@ -97,8 +95,8 @@ jobs:
           # rebase しながら数回まで再試行する
           for attempt in 1 2 3 4; do
             if git push origin HEAD:main; then
-              echo "pushed=true" >> $GITHUB_OUTPUT
-              echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "push に失敗しました (試行 ${attempt}/4)。rebase して再試行します"
@@ -111,27 +109,17 @@ jobs:
       # 無人運用なので、失敗したら気づけるように自動でissueを立てる
       - name: Report failure as issue
         if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh label create automation-failure --color B60205 \
-            --description "自動更新ワークフローの失敗" 2>/dev/null || true
+        uses: ./.github/actions/report-failure
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 自動更新ワークフローが失敗しました
+          body: |
+            自動更新ワークフローが失敗しました。検証を通らなかったため、記事のコミットと公開は行われていません。
 
-          body="自動更新ワークフローが失敗しました。検証を通らなかったため、記事のコミットと公開は行われていません。
+            - 実行ログ: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - 生成物は artifact `failed-build` に保存されています
 
-          - 実行ログ: ${RUN_URL}
-          - 生成物は artifact \`failed-build\` に保存されています
-
-          再実行する場合は Actions から \`Update Blog with Hatena Bookmarks\` を workflow_dispatch してください。"
-
-          existing=$(gh issue list --label automation-failure --state open --limit 1 --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
-          else
-            gh issue create --title "自動更新ワークフローが失敗しました" \
-              --label automation-failure --body "$body"
-          fi
+            再実行する場合は Actions から `Update Blog with Hatena Bookmarks` を workflow_dispatch してください。
 
   # push しただけでは公開されないので、ここから Pages へのデプロイを呼ぶ。
   # deploy.yml 側の push トリガーはこの push では起動しない
@@ -146,32 +134,30 @@ jobs:
     with:
       ref: ${{ needs.update-blog.outputs.sha }}
 
-  # 記事はコミット済みなのに公開だけ落ちた状態に気づけるようにする
+  # 記事はコミット済みなのに公開だけ落ちた状態に気づけるようにする。
+  # deploy の結果を明示的に見る: 単なる failure() では、update-blog が落ちて deploy が
+  # スキップされたときにも動いてしまい、「コミットは成功した」という誤った issue が立つ
   report-deploy-failure:
-    needs: deploy
-    if: failure()
+    needs: [update-blog, deploy]
+    if: always() && needs.update-blog.outputs.pushed == 'true' && needs.deploy.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Report failure as issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh label create automation-failure --color B60205 \
-            --description "自動更新ワークフローの失敗" 2>/dev/null || true
+        uses: ./.github/actions/report-failure
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 自動更新した記事の公開に失敗しました
+          body: |
+            自動生成した記事のコミットは成功しましたが、GitHub Pages への公開に失敗しました。main には記事があるのにサイトに出ていない状態です。
 
-          body="自動生成した記事のコミットは成功しましたが、GitHub Pages への公開に失敗しました。main には記事があるのにサイトに出ていない状態です。
+            - 対象コミット: ${{ needs.update-blog.outputs.sha }}
+            - 実行ログ: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          - 実行ログ: ${RUN_URL}
-
-          再実行する場合は Actions から \`Deploy Astro site to Pages\` を workflow_dispatch してください。"
-
-          existing=$(gh issue list --label automation-failure --state open --limit 1 --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
-          else
-            gh issue create --title "自動更新した記事の公開に失敗しました" \
-              --label automation-failure --body "$body"
-          fi
+            再実行する場合は Actions から `Deploy Astro site to Pages` を workflow_dispatch してください。

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -30,22 +30,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      # Node のセットアップは .github/actions/setup に集約している
+      - name: Setup
+        uses: ./.github/actions/setup
 
       # 要約は日次記事から流用するので、Gemini APIは呼ばない
       - name: Build weekly digest
+        env:
+          # 入力を直接コマンド行に展開しない（式の中身がそのまま shell に渡るのを避ける）
+          WEEK_ENDING: ${{ inputs.week_ending }}
         run: |
-          if [ -n "${{ inputs.week_ending }}" ]; then
-            npm run weekly-digest -- --week-ending "${{ inputs.week_ending }}"
+          set -euo pipefail
+          if [ -n "${WEEK_ENDING:-}" ]; then
+            npm run weekly-digest -- --week-ending "$WEEK_ENDING"
           else
             npm run weekly-digest
           fi
@@ -53,10 +52,11 @@ jobs:
       - name: Check for changes
         id: verify-changed-files
         run: |
+          set -euo pipefail
           if [ -n "$(git status --porcelain _posts/)" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       # ここから公開前ゲート: 検証を通らなかったものはコミットしない
@@ -67,7 +67,7 @@ jobs:
       - name: Build Astro site
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run build 2>&1 | tee build.log
 
       - name: Validate build output
@@ -78,13 +78,14 @@ jobs:
 
       - name: Upload build output on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failed-weekly-build
           path: |
             build.log
             _posts/
           if-no-files-found: ignore
+          retention-days: 14
 
       # 検証を通ったのでコミットして push する。
       # GITHUB_TOKEN による push は deploy.yml の push トリガーを起動しないので、
@@ -93,6 +94,7 @@ jobs:
         id: commit
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
+          set -euo pipefail
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add _posts/
@@ -102,8 +104,8 @@ jobs:
           # rebase しながら数回まで再試行する
           for attempt in 1 2 3 4; do
             if git push origin HEAD:main; then
-              echo "pushed=true" >> $GITHUB_OUTPUT
-              echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "push に失敗しました (試行 ${attempt}/4)。rebase して再試行します"
@@ -116,27 +118,17 @@ jobs:
       # 無人運用なので、失敗したら気づけるように自動でissueを立てる
       - name: Report failure as issue
         if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh label create automation-failure --color B60205 \
-            --description "自動更新ワークフローの失敗" 2>/dev/null || true
+        uses: ./.github/actions/report-failure
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 週刊まとめの生成が失敗しました
+          body: |
+            週刊まとめの生成が失敗しました。検証を通らなかったため、記事のコミットと公開は行われていません。
 
-          body="週刊まとめの生成が失敗しました。検証を通らなかったため、記事のコミットと公開は行われていません。
+            - 実行ログ: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - 生成物は artifact `failed-weekly-build` に保存されています
 
-          - 実行ログ: ${RUN_URL}
-          - 生成物は artifact \`failed-weekly-build\` に保存されています
-
-          再実行する場合は Actions から \`Build Weekly Digest\` を workflow_dispatch してください。"
-
-          existing=$(gh issue list --label automation-failure --state open --limit 1 --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
-          else
-            gh issue create --title "週刊まとめの生成が失敗しました" \
-              --label automation-failure --body "$body"
-          fi
+            再実行する場合は Actions から `Build Weekly Digest` を workflow_dispatch してください。
 
   # push しただけでは公開されないので、ここから Pages へのデプロイを呼ぶ
   deploy:
@@ -150,32 +142,30 @@ jobs:
     with:
       ref: ${{ needs.weekly-digest.outputs.sha }}
 
-  # 記事はコミット済みなのに公開だけ落ちた状態に気づけるようにする
+  # 記事はコミット済みなのに公開だけ落ちた状態に気づけるようにする。
+  # deploy の結果を明示的に見る: 単なる failure() では、weekly-digest が落ちて deploy が
+  # スキップされたときにも動いてしまい、「コミットは成功した」という誤った issue が立つ
   report-deploy-failure:
-    needs: deploy
-    if: failure()
+    needs: [weekly-digest, deploy]
+    if: always() && needs.weekly-digest.outputs.pushed == 'true' && needs.deploy.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Report failure as issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh label create automation-failure --color B60205 \
-            --description "自動更新ワークフローの失敗" 2>/dev/null || true
+        uses: ./.github/actions/report-failure
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 週刊まとめの公開に失敗しました
+          body: |
+            週刊まとめのコミットは成功しましたが、GitHub Pages への公開に失敗しました。
 
-          body="週刊まとめのコミットは成功しましたが、GitHub Pages への公開に失敗しました。
+            - 対象コミット: ${{ needs.weekly-digest.outputs.sha }}
+            - 実行ログ: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          - 実行ログ: ${RUN_URL}
-
-          再実行する場合は Actions から \`Deploy Astro site to Pages\` を workflow_dispatch してください。"
-
-          existing=$(gh issue list --label automation-failure --state open --limit 1 --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
-          else
-            gh issue create --title "週刊まとめの公開に失敗しました" \
-              --label automation-failure --body "$body"
-          fi
+            再実行する場合は Actions から `Deploy Astro site to Pages` を workflow_dispatch してください。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@ npm test
 # Build and validate before publishing (公開前ゲートと同じ検証)
 npm run build 2>&1 | tee build.log
 npm run validate -- --log build.log --feed dist/feed.xml --dist dist
+
+# Render the coverage summary the way CI comments it on a pull request
+npm run test:coverage
+npm run coverage-report -- --min-lines 85
+
+# Check the *published* site (更新が止まっていないか)
+npm run health-check
 ```
 
 **Publishing gate**: broken front matter fails the build via the content collection
@@ -48,6 +55,14 @@ newest 20 entries, so anything older that stops being generated is invisible to 
 feed checks. The daily automation runs this gate *before*
 committing — nothing that fails validation is committed or published, and a failure
 opens an issue automatically.
+
+**Anomaly detection**: the publishing gate only sees a build that actually ran, so it
+cannot notice the ways this repo breaks *quietly* — the cron stops firing, a run goes
+green without producing a post, or Pages keeps serving a stale artifact. `health-check.yml`
+covers that gap: it runs daily (2h after the daily post) and `scripts/check-site-health.ts`
+fetches the **published** `feed.xml` to check that it parses, has no empty titles or
+duplicate URLs, and that the newest entry is not older than `--max-age-hours` (36h — 24h
+would false-alarm depending on when the run lands). A problem opens a `site-health` issue.
 
 ### Docker Development (Recommended)
 ```bash
@@ -132,12 +147,15 @@ docker compose run --rm scripts npm test
   - `scripts/build-weekly-digest.ts`: 日次記事7本を束ねる週刊まとめ（AIは呼ばない）
   - `scripts/generate_og_image.mjs`: OGP画像の生成（手動実行、結果をコミットする）
   - `scripts/validate-build.ts`: pre-publish gate over the build log and feed.xml
+  - `scripts/check-site-health.ts`: 公開中の feed.xml を外から検査する異常検知
+  - `scripts/coverage-report.ts`: vitest のカバレッジを Markdown 化（PRコメント用）
   - `scripts/lib/`: 共通部品。`date.ts`（JST固定オフセットの暦日）, `frontmatter.ts`
     （front matter の生成／分割。Astro と同じ js-yaml を使う）, `http.ts`（タイムアウト付き
     取得と charset 判定）, `rss.ts`（RSS 1.0/2.0・Atom を同じ形に正規化）,
     `article.ts`（cheerio による本文抽出）, `xml-node.ts`, `fs.ts`, `logger.ts`
   - `tests/`: vitest tests for the scripts (Gemini SDK と fetch はモックする)
-- **CI/CD**: `.github/workflows/` for automated deployment and content updates
+- **CI/CD**: `.github/workflows/` for automated deployment and content updates, plus
+  `.github/actions/` — the composite actions (`setup`, `report-failure`) the workflows share
 
 ### Key Features
 - **Pagination**: 10 posts per page with Japanese navigation ("前へ"/"次へ"); page 1 is
@@ -269,6 +287,18 @@ writing it — useful for checking the output length after a prompt change.
   Node setup runs the automation scripts, so no Python toolchain is installed in CI.
   `test.yml` runs on pull requests only — a push to `main` already gets the same build and
   publishing gate from `deploy.yml`, so keeping both would build every merge twice
+- **Shared composite actions**: every workflow starts with the same checkout + Node setup and
+  three of them report failures the same way, so those live in `.github/actions/setup` and
+  `.github/actions/report-failure`. Bumping Node or changing how failures are reported is a
+  one-file edit. `report-failure` comments on the existing open issue with the same label
+  instead of opening a new one — a daily failure would otherwise pile up issues
+- **Action versions**: `dependabot.yml` watches `github-actions` and `npm` weekly and groups
+  the `actions/*` bumps into one PR. `test.yml` also runs **actionlint** so a broken
+  workflow expression fails the PR instead of the next scheduled run
+- **Workflow failure reporting**: `report-deploy-failure` gates on
+  `needs.deploy.result == 'failure'`, not on a bare `failure()`. A bare `failure()` also
+  fires when the *build* job failed and `deploy` was skipped, which posted an issue claiming
+  the article had been committed when nothing was
 - **Node base image**: the Dockerfiles use `node:22-slim` rather than Alpine because the
   Pagefind binary that `npm ci` fetches is built against glibc
 - **Testing Isolation**: Tests run in containerized environment with mocked external dependencies
@@ -276,6 +306,15 @@ writing it — useful for checking the output length after a prompt change.
 ### Testing Strategy
 - **One test runner**: `npm test` (vitest) covers both `src/lib/*.test.ts` and `tests/*.test.ts`
   (the automation scripts). `npm run test:coverage` adds the coverage report
+- **Coverage on pull requests**: `test.yml` runs `test:coverage`, turns the
+  `coverage-summary.json` into Markdown with `scripts/coverage-report.ts`, and posts it as a
+  single sticky comment (found by the `<!-- coverage-report -->` marker and updated in place,
+  so re-pushing does not bury the PR). The same Markdown goes to the job summary, which is the
+  only place a fork PR can show it — a fork's `GITHUB_TOKEN` is read-only and commenting fails.
+  `MIN_LINE_COVERAGE` in `test.yml` (85%, against ~91% today) fails the PR when coverage drops;
+  the comment is posted first so the number is visible either way.
+  `src/lib/posts.ts` is excluded from the coverage config — it imports `astro:content` and can
+  never be tested, so counting it as 0% would make the total useless as a threshold
 - **Frontend Tests**: only modules that do not import `astro:content` can be tested this way,
   which is why the pure helpers live in `format.ts` / `bookmarks.ts` / `feed.ts` / `xml.ts`
   rather than in `posts.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,10 @@ writing it — useful for checking the output length after a prompt change.
   `needs.deploy.result == 'failure'`, not on a bare `failure()`. A bare `failure()` also
   fires when the *build* job failed and `deploy` was skipped, which posted an issue claiming
   the article had been committed when nothing was
-- **Node base image**: the Dockerfiles use `node:22-slim` rather than Alpine because the
+- **Node version**: Node 24 (Active LTS — 22 has dropped to Maintenance). It is set in two
+  places that must stay in sync: the `node-version` default in `.github/actions/setup`
+  (all of CI) and `node:24-slim` in `Dockerfile` / `Dockerfile.production`
+- **Node base image**: the Dockerfiles use `node:24-slim` rather than Alpine because the
   Pagefind binary that `npm ci` fetches is built against glibc
 - **Testing Isolation**: Tests run in containerized environment with mocked external dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM node:22-slim AS build
+FROM node:24-slim AS build
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ npm run validate -- --log build.log --feed dist/feed.xml --dist dist
 `--dist` を渡すと、`_posts/` の記事がすべてページとして出力されているかも検査します
 （feed.xml は最新20件しか載らないため、それより古い記事の消失はこの検査で捕まえます）。
 
+### 公開中のサイトの異常検知
+
+```bash
+npm run health-check
+```
+
+公開されている `feed.xml` を取りに行き、壊れていないか・最新記事が古すぎないかを確かめます。
+公開前の検証はビルドした結果しか見ないため、「cron が止まった」「実行は成功したのに記事が
+増えていない」といった静かな壊れ方はこちらでしか気づけません。
+`health-check.yml` が毎日 10:00 JST に実行し、異常があれば issue を立てます。
+
+### カバレッジ
+
+```bash
+npm run test:coverage
+npm run coverage-report -- --min-lines 85
+```
+
+プルリクエストでは `test.yml` が同じ内容をコメントとして貼り、行カバレッジが 85% を
+下回ると失敗させます。コメントは毎回作り直さず同じものを更新します。
+
 ### Docker関連
 
 ```bash
@@ -138,10 +159,15 @@ docker compose run --rm scripts npm test
 │   ├── fetch-and-summarize.ts
 │   ├── build-weekly-digest.ts
 │   ├── validate-build.ts
+│   ├── check-site-health.ts # 公開中のサイトの異常検知
+│   ├── coverage-report.ts   # カバレッジをPRコメント用のMarkdownにする
 │   ├── generate_og_image.mjs
 │   └── lib/                 # RSS・本文抽出・日付・front matter などの共通部品
 ├── tests/                   # scripts/ のユニットテスト（vitest）
-└── .github/workflows/       # CI/CD設定
+└── .github/
+    ├── workflows/           # CI/CD設定
+    ├── actions/             # ワークフローで共有する composite action
+    └── dependabot.yml       # Action と npm パッケージの更新
 ```
 
 ## 📝 記事の作成

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Astro で構築された日本語のブログサイトです。モダンなデ�
 
 ## 📋 必要な環境
 
-- Node.js 22以上（自動化スクリプトも TypeScript なので Node だけで動きます）
+- Node.js 24以上（自動化スクリプトも TypeScript なので Node だけで動きます）
+  CI と Docker は Node 24（Active LTS）を使います
 - Docker & Docker Compose（推奨）
 
 ## 🛠️ 環境構築

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "astro": "astro",
     "summarize": "tsx scripts/fetch-and-summarize.ts",
     "weekly-digest": "tsx scripts/build-weekly-digest.ts",
-    "validate": "tsx scripts/validate-build.ts"
+    "validate": "tsx scripts/validate-build.ts",
+    "coverage-report": "tsx scripts/coverage-report.ts",
+    "health-check": "tsx scripts/check-site-health.ts"
   },
   "dependencies": {
     "@google/genai": "^2.13.0",

--- a/scripts/check-site-health.ts
+++ b/scripts/check-site-health.ts
@@ -1,0 +1,237 @@
+/**
+ * 公開中のサイトの異常検知。
+ *
+ * 公開前ゲート（validate-build.ts）はビルド結果しか見ないので、
+ * 「ワークフローが緑のまま記事が作られなくなった」「デプロイが古い成果物を
+ * 出し続けている」といった、CI が失敗しないまま静かに壊れる状態は捕まえられない。
+ * ここでは実際に公開されている feed.xml を取りに行って、
+ *
+ *   - サイトが応答するか
+ *   - フィードが壊れていないか（空タイトル・URL重複）
+ *   - 最新記事が古すぎないか（日次更新が止まっていないか）
+ *
+ * を確かめる。定期実行して、問題があれば issue を立てるのに使う。
+ *
+ * 使い方:
+ *     npm run health-check -- --feed https://example.com/feed.xml --max-age-hours 36
+ */
+
+import { pathToFileURL } from 'node:url';
+
+import { XMLParser } from 'fast-xml-parser';
+
+import { fetchText } from './lib/http.ts';
+import { describeError } from './lib/logger.ts';
+import { asArray, attrOf, isNode, textOf } from './lib/xml-node.ts';
+
+const DEFAULT_FEED_URL = 'https://6uclz1.github.io/claude-code-blog-site/feed.xml';
+
+/**
+ * 最新記事の許容される古さ（時間）。
+ *
+ * 日次記事の date は実行時刻ではなく対象日の 09:00 JST に固定されている
+ * （scripts/lib/date.ts の postDateStamp）。D日 08:00 JST の実行が作るのは
+ * D-1日 09:00 JST の記事なので、健全なら 10:00 JST の点検時点で必ず約25時間前。
+ * 1回飛べば約49時間前になる。36時間はその中間で、正常時に鳴らず1回の失敗を逃さない。
+ */
+const DEFAULT_MAX_AGE_HOURS = 36;
+
+const FETCH_TIMEOUT_MS = 30_000;
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+});
+
+export interface FeedEntry {
+  title: string;
+  link: string;
+  updated?: string;
+}
+
+/** Atom フィードから記事を取り出す。読めない形なら例外 */
+export function parseFeed(xml: string): FeedEntry[] {
+  const parsed: unknown = parser.parse(xml);
+  if (!isNode(parsed)) throw new Error('フィードを XML として解釈できません');
+
+  const feed = parsed['feed'];
+  if (!isNode(feed)) throw new Error('Atom の <feed> がありません');
+
+  return asArray(feed['entry'])
+    .filter(isNode)
+    .map((entry) => ({
+      title: textOf(entry['title']),
+      link: attrOf(asArray(entry['link'])[0], 'href'),
+      updated: textOf(entry['updated']) || textOf(entry['published']) || undefined,
+    }));
+}
+
+export interface CheckOptions {
+  maxAgeHours: number;
+  minEntries: number;
+  now?: Date;
+}
+
+/** フィードの中身を検査して、見つかった異常を日本語で返す */
+export function checkEntries(entries: FeedEntry[], options: CheckOptions): string[] {
+  const problems: string[] = [];
+  const now = options.now ?? new Date();
+
+  if (entries.length < options.minEntries) {
+    problems.push(
+      `フィードの記事が ${entries.length} 件しかありません（${options.minEntries} 件以上を期待）`
+    );
+  }
+
+  if (entries.some((entry) => entry.title.trim() === '')) {
+    problems.push('タイトルが空の記事がフィードに含まれています');
+  }
+
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (entry.link === '') {
+      problems.push('リンクのない記事がフィードに含まれています');
+      continue;
+    }
+    if (seen.has(entry.link)) problems.push(`同じURLの記事が複数あります: ${entry.link}`);
+    seen.add(entry.link);
+  }
+
+  // 「更新が止まった」を捕まえるのがこの検査の主目的。
+  // 最新1件だけ見れば足りる（古い記事の日付は変わらない）
+  const newest = newestTimestamp(entries);
+  if (entries.length > 0 && newest === undefined) {
+    problems.push('フィードの記事に読める日付がありません');
+  } else if (newest !== undefined) {
+    const ageHours = (now.getTime() - newest.getTime()) / 3_600_000;
+    if (ageHours > options.maxAgeHours) {
+      problems.push(
+        `最新記事が ${Math.floor(ageHours)} 時間前で止まっています` +
+          `（${options.maxAgeHours} 時間以内を期待）。自動更新が動いていない可能性があります`
+      );
+    }
+    // 未来の日付は、生成時に実行時刻を使ってしまったときに出る典型的な壊れ方
+    if (ageHours < -24) {
+      problems.push(`最新記事の日付が未来になっています: ${newest.toISOString()}`);
+    }
+  }
+
+  return problems;
+}
+
+function newestTimestamp(entries: FeedEntry[]): Date | undefined {
+  let newest: Date | undefined;
+  for (const entry of entries) {
+    if (!entry.updated) continue;
+    const parsed = new Date(entry.updated);
+    if (Number.isNaN(parsed.getTime())) continue;
+    if (!newest || parsed > newest) newest = parsed;
+  }
+  return newest;
+}
+
+export interface HealthResult {
+  ok: boolean;
+  problems: string[];
+  entryCount: number;
+}
+
+export async function checkSite(
+  feedUrl: string,
+  options: CheckOptions,
+  fetchFeed: (url: string) => Promise<string> = (url) =>
+    fetchText(url, { timeoutMs: FETCH_TIMEOUT_MS })
+): Promise<HealthResult> {
+  let xml: string;
+  try {
+    xml = await fetchFeed(feedUrl);
+  } catch (error) {
+    // 取得できない時点で以降の検査は無意味なので、ここで打ち切る
+    return { ok: false, problems: [`フィードを取得できません: ${describeError(error)}`], entryCount: 0 };
+  }
+
+  let entries: FeedEntry[];
+  try {
+    entries = parseFeed(xml);
+  } catch (error) {
+    return { ok: false, problems: [`フィードが壊れています: ${describeError(error)}`], entryCount: 0 };
+  }
+
+  const problems = checkEntries(entries, options);
+  return { ok: problems.length === 0, problems, entryCount: entries.length };
+}
+
+interface CliArgs extends CheckOptions {
+  feed: string;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    feed: DEFAULT_FEED_URL,
+    maxAgeHours: DEFAULT_MAX_AGE_HOURS,
+    minEntries: 1,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index]!;
+    const [flag, inline] = raw.includes('=')
+      ? [raw.slice(0, raw.indexOf('=')), raw.slice(raw.indexOf('=') + 1)]
+      : [raw, undefined];
+    const value = () => {
+      const next = inline ?? argv[++index];
+      if (next === undefined) throw new Error(`${flag} には値が必要です`);
+      return next;
+    };
+    const numeric = (flag: string) => {
+      const parsed = Number(value());
+      if (!Number.isFinite(parsed)) throw new Error(`${flag} には数値が必要です`);
+      return parsed;
+    };
+
+    switch (flag) {
+      case '--feed':
+        args.feed = value();
+        break;
+      case '--max-age-hours':
+        args.maxAgeHours = numeric(flag);
+        break;
+      case '--min-entries':
+        args.minEntries = numeric(flag);
+        break;
+      default:
+        throw new Error(`不明な引数: ${flag}`);
+    }
+  }
+
+  return args;
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(`${describeError(error)}\n`);
+    return 2;
+  }
+
+  const result = await checkSite(args.feed, args);
+  if (!result.ok) {
+    process.stderr.write(`❌ サイトに異常があります (${args.feed}):\n`);
+    for (const problem of result.problems) process.stderr.write(`  - ${problem}\n`);
+    return 1;
+  }
+
+  process.stdout.write(`✅ サイトは正常です (${result.entryCount} 件の記事, ${args.feed})\n`);
+  return 0;
+}
+
+// スクリプトとして実行されたときだけ動かす（テストからの import では動かさない）
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -1,0 +1,249 @@
+/**
+ * vitest のカバレッジ結果を Markdown にする（プルリクにコメントするため）。
+ *
+ * `npm run test:coverage` が書き出す `coverage/coverage-summary.json` を読み、
+ * 全体の数字とファイル別の内訳を1つの表にまとめる。CI はこの出力をそのまま
+ * PR のコメントとジョブサマリに貼る。
+ *
+ * しきい値（--min-lines）を下回ったときは非ゼロで終了する。カバレッジは
+ * 下がったことに気づけて初めて意味があるので、コメントを出すだけでは足りない。
+ *
+ * 使い方:
+ *     npm run coverage-report -- --summary coverage/coverage-summary.json --min-lines 85
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describeError } from './lib/logger.ts';
+
+/** PR コメントを毎回作り直さず上書きするための目印 */
+export const COMMENT_MARKER = '<!-- coverage-report -->';
+
+/** カバレッジが低いファイルだけ並べても意味がないので、全ファイルを出す上限 */
+const MAX_FILE_ROWS = 40;
+
+export interface Metric {
+  total: number;
+  covered: number;
+  pct: number;
+}
+
+export interface FileCoverage {
+  lines: Metric;
+  statements: Metric;
+  functions: Metric;
+  branches: Metric;
+}
+
+export interface CoverageSummary {
+  total: FileCoverage;
+  files: { path: string; coverage: FileCoverage }[];
+}
+
+const METRIC_KEYS = ['lines', 'statements', 'functions', 'branches'] as const;
+
+function asMetric(value: unknown): Metric | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const pct = record['pct'];
+  const total = record['total'];
+  const covered = record['covered'];
+  if (typeof pct !== 'number' || typeof total !== 'number' || typeof covered !== 'number') {
+    return undefined;
+  }
+  return { pct, total, covered };
+}
+
+function asFileCoverage(value: unknown): FileCoverage | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const metrics = {} as Record<(typeof METRIC_KEYS)[number], Metric>;
+  for (const key of METRIC_KEYS) {
+    const metric = asMetric(record[key]);
+    if (!metric) return undefined;
+    metrics[key] = metric;
+  }
+  return metrics as FileCoverage;
+}
+
+/**
+ * coverage-summary.json を読む。
+ *
+ * ファイルのキーは実行環境の絶対パスなので、リポジトリからの相対パスに直す
+ * （CI のランナー上の `/home/runner/work/...` をそのまま貼っても読めない）。
+ */
+export function parseSummary(json: string, root: string = process.cwd()): CoverageSummary {
+  const parsed: unknown = JSON.parse(json);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('coverage-summary.json の形式が不正です');
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const total = asFileCoverage(record['total']);
+  if (!total) throw new Error('coverage-summary.json に total がありません');
+
+  const files: CoverageSummary['files'] = [];
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'total') continue;
+    const coverage = asFileCoverage(value);
+    if (!coverage) continue;
+    const relative = path.isAbsolute(key) ? path.relative(root, key) : key;
+    files.push({ path: relative.split(path.sep).join('/'), coverage });
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return { total, files };
+}
+
+const format = (metric: Metric) => `${metric.pct.toFixed(2)}%`;
+
+/** 一目で危ないファイルが分かるように、行カバレッジで色分けする */
+export function statusIcon(pct: number): string {
+  if (pct >= 90) return '🟢';
+  if (pct >= 75) return '🟡';
+  return '🔴';
+}
+
+function row(name: string, coverage: FileCoverage): string {
+  const cells = METRIC_KEYS.map((key) => format(coverage[key]));
+  return `| ${statusIcon(coverage.lines.pct)} ${name} | ${cells.join(' | ')} |`;
+}
+
+export interface RenderOptions {
+  /** 下回ったら失敗にする行カバレッジ（%）。未指定ならしきい値なし */
+  minLines?: number;
+  /** コメントに実行ログへのリンクを載せる */
+  runUrl?: string;
+}
+
+export function renderMarkdown(summary: CoverageSummary, options: RenderOptions = {}): string {
+  const { total, files } = summary;
+  const lines: string[] = [COMMENT_MARKER, '## 🧪 テストカバレッジ', ''];
+
+  lines.push('| 対象 | Lines | Statements | Functions | Branches |');
+  lines.push('| --- | ---: | ---: | ---: | ---: |');
+  lines.push(row('**全体**', total));
+  lines.push('');
+
+  if (options.minLines !== undefined) {
+    const ok = total.lines.pct >= options.minLines;
+    lines.push(
+      ok
+        ? `しきい値 ${options.minLines}% を満たしています（Lines ${format(total.lines)}）。`
+        : `⚠️ しきい値 ${options.minLines}% を下回りました（Lines ${format(total.lines)}）。`
+    );
+    lines.push('');
+  }
+
+  if (files.length > 0) {
+    // 数十行の表を常に開いておくとレビューの邪魔になるので折りたたむ。
+    // 並びは「低い順」— 見るべきものが上に来る
+    const sorted = [...files].sort((a, b) => a.coverage.lines.pct - b.coverage.lines.pct);
+    const shown = sorted.slice(0, MAX_FILE_ROWS);
+
+    lines.push('<details><summary>ファイル別（カバレッジの低い順）</summary>', '');
+    lines.push('| ファイル | Lines | Statements | Functions | Branches |');
+    lines.push('| --- | ---: | ---: | ---: | ---: |');
+    for (const file of shown) lines.push(row(`\`${file.path}\``, file.coverage));
+    if (sorted.length > shown.length) {
+      lines.push('');
+      lines.push(`ほか ${sorted.length - shown.length} ファイル`);
+    }
+    lines.push('', '</details>');
+  }
+
+  if (options.runUrl) {
+    lines.push('', `[実行ログ](${options.runUrl}) · \`npm run test:coverage\` で手元でも確認できます`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+interface CliArgs {
+  summary: string;
+  out?: string;
+  minLines?: number;
+  runUrl?: string;
+  root: string;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { summary: 'coverage/coverage-summary.json', root: process.cwd() };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index]!;
+    const [flag, inline] = raw.includes('=')
+      ? [raw.slice(0, raw.indexOf('=')), raw.slice(raw.indexOf('=') + 1)]
+      : [raw, undefined];
+    const value = () => {
+      const next = inline ?? argv[++index];
+      if (next === undefined) throw new Error(`${flag} には値が必要です`);
+      return next;
+    };
+
+    switch (flag) {
+      case '--summary':
+        args.summary = value();
+        break;
+      case '--out':
+        args.out = value();
+        break;
+      case '--min-lines': {
+        const parsed = Number(value());
+        if (!Number.isFinite(parsed)) throw new Error('--min-lines には数値が必要です');
+        args.minLines = parsed;
+        break;
+      }
+      case '--run-url':
+        args.runUrl = value();
+        break;
+      case '--root':
+        args.root = value();
+        break;
+      default:
+        throw new Error(`不明な引数: ${flag}`);
+    }
+  }
+
+  return args;
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(`${describeError(error)}\n`);
+    return 2;
+  }
+
+  let summary: CoverageSummary;
+  try {
+    summary = parseSummary(await readFile(args.summary, 'utf-8'), args.root);
+  } catch (error) {
+    process.stderr.write(`カバレッジを読めませんでした: ${describeError(error)}\n`);
+    return 2;
+  }
+
+  const markdown = renderMarkdown(summary, { minLines: args.minLines, runUrl: args.runUrl });
+  if (args.out) await writeFile(args.out, markdown, 'utf-8');
+  else process.stdout.write(markdown);
+
+  if (args.minLines !== undefined && summary.total.lines.pct < args.minLines) {
+    process.stderr.write(
+      `❌ 行カバレッジ ${summary.total.lines.pct.toFixed(2)}% が ` +
+        `しきい値 ${args.minLines}% を下回りました\n`
+    );
+    return 1;
+  }
+  return 0;
+}
+
+// スクリプトとして実行されたときだけ動かす（テストからの import では動かさない）
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/tests/check-site-health.test.ts
+++ b/tests/check-site-health.test.ts
@@ -1,0 +1,207 @@
+/** 公開中のサイトの異常検知(scripts/check-site-health.ts)のテスト */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  checkEntries,
+  checkSite,
+  main,
+  parseArgs,
+  parseFeed,
+  type FeedEntry,
+} from '../scripts/check-site-health.ts';
+import { okResponse } from './helpers.ts';
+
+const HOUR = 3_600_000;
+const NOW = new Date('2026-07-28T00:00:00Z');
+
+const hoursAgo = (hours: number) => new Date(NOW.getTime() - hours * HOUR).toISOString();
+
+function feed(...entries: string[]): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">${entries.join('')}
+</feed>
+`;
+}
+
+function entry({
+  title = 'はてなブックマーク 2026年07月27日 の記事まとめ',
+  href = 'https://example.com/2026/07/27/hatena-bookmarks/',
+  updated = hoursAgo(6),
+} = {}): string {
+  return `
+  <entry>
+    <title type="html">${title}</title>
+    <link href="${href}" rel="alternate" type="text/html"/>
+    <published>${updated}</published>
+    <updated>${updated}</updated>
+  </entry>`;
+}
+
+const options = { maxAgeHours: 36, minEntries: 1, now: NOW };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('parseFeed', () => {
+  it('タイトル・リンク・日付を取り出す', () => {
+    const [parsed] = parseFeed(feed(entry({ title: 'まとめ', href: 'https://example.com/a/' })));
+
+    expect(parsed).toMatchObject({ title: 'まとめ', link: 'https://example.com/a/' });
+  });
+
+  it('記事が1件でも配列で返す', () => {
+    expect(parseFeed(feed(entry()))).toHaveLength(1);
+  });
+
+  it('記事が複数でも全部返す', () => {
+    expect(parseFeed(feed(entry(), entry({ href: 'https://example.com/b/' })))).toHaveLength(2);
+  });
+
+  it('記事がなければ空配列', () => {
+    expect(parseFeed(feed())).toEqual([]);
+  });
+
+  it('<feed> でなければ例外', () => {
+    expect(() => parseFeed('<rss><channel/></rss>')).toThrow(/feed/);
+  });
+});
+
+describe('checkEntries', () => {
+  const entries = (...items: Partial<FeedEntry>[]): FeedEntry[] =>
+    items.map((item) => ({
+      title: 'まとめ',
+      link: 'https://example.com/a/',
+      updated: hoursAgo(6),
+      ...item,
+    }));
+
+  it('正常なフィードは問題なしとする', () => {
+    expect(checkEntries(entries({}), options)).toEqual([]);
+  });
+
+  it('最新記事が古すぎたら止まっていると判断する', () => {
+    const problems = checkEntries(entries({ updated: hoursAgo(72) }), options);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/自動更新が動いていない/);
+  });
+
+  it('しきい値ちょうどは正常とする', () => {
+    expect(checkEntries(entries({ updated: hoursAgo(36) }), options)).toEqual([]);
+  });
+
+  it('最新記事が新しければ古い記事があっても問題にしない', () => {
+    expect(
+      checkEntries(
+        entries({ updated: hoursAgo(6) }, { link: 'https://example.com/b/', updated: hoursAgo(900) }),
+        options
+      )
+    ).toEqual([]);
+  });
+
+  it('未来の日付を見つける', () => {
+    const problems = checkEntries(entries({ updated: hoursAgo(-48) }), options);
+
+    expect(problems.join()).toMatch(/未来/);
+  });
+
+  it('空のタイトルを見つける', () => {
+    expect(checkEntries(entries({ title: '  ' }), options).join()).toMatch(/タイトルが空/);
+  });
+
+  it('URLの重複を見つける', () => {
+    const problems = checkEntries(entries({}, {}), options);
+
+    expect(problems.join()).toMatch(/同じURLの記事/);
+  });
+
+  it('リンクのない記事を見つける', () => {
+    expect(checkEntries(entries({ link: '' }), options).join()).toMatch(/リンクのない記事/);
+  });
+
+  it('記事が足りなければ問題にする', () => {
+    expect(checkEntries([], { ...options, minEntries: 1 }).join()).toMatch(/記事が 0 件/);
+  });
+
+  it('日付の読めない記事しかなければ問題にする', () => {
+    expect(checkEntries(entries({ updated: undefined }), options).join()).toMatch(/読める日付/);
+  });
+});
+
+describe('checkSite', () => {
+  it('正常なサイトは ok を返す', async () => {
+    const result = await checkSite('https://example.com/feed.xml', options, async () =>
+      feed(entry())
+    );
+
+    expect(result).toMatchObject({ ok: true, entryCount: 1 });
+  });
+
+  it('取得できなければ ok=false（以降の検査はしない）', async () => {
+    const result = await checkSite('https://example.com/feed.xml', options, async () => {
+      throw new Error('HTTP 503');
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toEqual(['フィードを取得できません: HTTP 503']);
+  });
+
+  it('フィードが壊れていれば ok=false', async () => {
+    const result = await checkSite('https://example.com/feed.xml', options, async () => '<rss/>');
+
+    expect(result.ok).toBe(false);
+    expect(result.problems.join()).toMatch(/壊れています/);
+  });
+
+  it('既定では実際に HTTP で取りに行く', async () => {
+    const fetchMock = vi.fn(async () => okResponse(feed(entry()), 'application/xml'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await checkSite('https://example.com/feed.xml', options);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('parseArgs', () => {
+  it('既定値を持つ', () => {
+    expect(parseArgs([])).toMatchObject({ maxAgeHours: 36, minEntries: 1 });
+  });
+
+  it('引数を読む', () => {
+    expect(parseArgs(['--feed', 'https://example.com/f.xml', '--max-age-hours=48'])).toMatchObject({
+      feed: 'https://example.com/f.xml',
+      maxAgeHours: 48,
+    });
+  });
+
+  it('知らない引数は例外', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/不明な引数/);
+  });
+});
+
+describe('main', () => {
+  it('正常なら 0 を返す', async () => {
+    vi.stubGlobal('fetch', async () => okResponse(feed(entry()), 'application/xml'));
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    expect(await main(['--feed', 'https://example.com/feed.xml'])).toBe(0);
+  });
+
+  it('異常があれば 1 を返す', async () => {
+    vi.stubGlobal('fetch', async () => okResponse(feed(), 'application/xml'));
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    expect(await main(['--feed', 'https://example.com/feed.xml'])).toBe(1);
+  });
+
+  it('引数が不正なら 2 を返す', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    expect(await main(['--nope'])).toBe(2);
+  });
+});

--- a/tests/coverage-report.test.ts
+++ b/tests/coverage-report.test.ts
@@ -1,0 +1,185 @@
+/** カバレッジのMarkdown化(scripts/coverage-report.ts)のテスト */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  COMMENT_MARKER,
+  main,
+  parseArgs,
+  parseSummary,
+  renderMarkdown,
+  statusIcon,
+  type FileCoverage,
+} from '../scripts/coverage-report.ts';
+import { createTempDir } from './helpers.ts';
+
+const metric = (pct: number) => ({ total: 100, covered: Math.round(pct), pct });
+
+const coverage = (pct: number): FileCoverage => ({
+  lines: metric(pct),
+  statements: metric(pct),
+  functions: metric(pct),
+  branches: metric(pct),
+});
+
+const summaryJson = (files: Record<string, number>, totalPct: number) =>
+  JSON.stringify({
+    total: coverage(totalPct),
+    ...Object.fromEntries(Object.entries(files).map(([file, pct]) => [file, coverage(pct)])),
+  });
+
+let tmp: { dir: string; cleanup: () => Promise<void> };
+
+beforeEach(async () => {
+  tmp = await createTempDir();
+});
+afterEach(async () => {
+  await tmp.cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('parseSummary', () => {
+  it('全体とファイル別の数字を取り出す', () => {
+    const parsed = parseSummary(summaryJson({ '/repo/scripts/a.ts': 50 }, 88.82), '/repo');
+
+    expect(parsed.total.lines.pct).toBe(88.82);
+    expect(parsed.files).toEqual([{ path: 'scripts/a.ts', coverage: coverage(50) }]);
+  });
+
+  it('絶対パスをリポジトリからの相対パスに直す', () => {
+    const parsed = parseSummary(summaryJson({ '/home/runner/work/blog/src/lib/x.ts': 90 }, 90), '/home/runner/work/blog');
+
+    expect(parsed.files[0]!.path).toBe('src/lib/x.ts');
+  });
+
+  it('相対パスのキーはそのまま使う', () => {
+    const parsed = parseSummary(summaryJson({ 'src/lib/x.ts': 90 }, 90), '/repo');
+
+    expect(parsed.files[0]!.path).toBe('src/lib/x.ts');
+  });
+
+  it('total がなければ例外', () => {
+    expect(() => parseSummary('{"src/a.ts": {}}')).toThrow(/total/);
+  });
+
+  it('JSONでなければ例外', () => {
+    expect(() => parseSummary('not json')).toThrow();
+  });
+
+  it('形の合わないファイルの項目は無視する', () => {
+    const json = JSON.stringify({ total: coverage(90), 'src/a.ts': { lines: 'broken' } });
+
+    expect(parseSummary(json).files).toEqual([]);
+  });
+});
+
+describe('statusIcon', () => {
+  it('カバレッジで色を変える', () => {
+    expect(statusIcon(95)).toBe('🟢');
+    expect(statusIcon(80)).toBe('🟡');
+    expect(statusIcon(10)).toBe('🔴');
+  });
+});
+
+describe('renderMarkdown', () => {
+  const summary = parseSummary(
+    summaryJson({ 'src/lib/high.ts': 100, 'scripts/low.ts': 20 }, 88.82),
+    process.cwd()
+  );
+
+  it('コメントを上書きするための目印を先頭に置く', () => {
+    expect(renderMarkdown(summary).startsWith(COMMENT_MARKER)).toBe(true);
+  });
+
+  it('全体の数字を表に出す', () => {
+    expect(renderMarkdown(summary)).toContain('88.82%');
+  });
+
+  it('ファイル別はカバレッジの低い順に並べる', () => {
+    const markdown = renderMarkdown(summary);
+
+    expect(markdown.indexOf('scripts/low.ts')).toBeLessThan(markdown.indexOf('src/lib/high.ts'));
+  });
+
+  it('しきい値を下回ったら警告を出す', () => {
+    expect(renderMarkdown(summary, { minLines: 95 })).toContain('⚠️');
+  });
+
+  it('しきい値を満たしていれば警告を出さない', () => {
+    expect(renderMarkdown(summary, { minLines: 80 })).not.toContain('⚠️');
+  });
+
+  it('しきい値がなければ言及しない', () => {
+    expect(renderMarkdown(summary)).not.toContain('しきい値');
+  });
+
+  it('実行ログへのリンクを載せる', () => {
+    expect(renderMarkdown(summary, { runUrl: 'https://example.com/run/1' })).toContain(
+      'https://example.com/run/1'
+    );
+  });
+});
+
+describe('parseArgs', () => {
+  it('既定値を持つ', () => {
+    expect(parseArgs([]).summary).toBe('coverage/coverage-summary.json');
+  });
+
+  it('--flag=value 形式も読む', () => {
+    expect(parseArgs(['--min-lines=85']).minLines).toBe(85);
+  });
+
+  it('数値でないしきい値は例外', () => {
+    expect(() => parseArgs(['--min-lines', 'abc'])).toThrow(/数値/);
+  });
+
+  it('知らない引数は例外', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/不明な引数/);
+  });
+});
+
+describe('main', () => {
+  const write = async (name: string, content: string) => {
+    const filePath = path.join(tmp.dir, name);
+    await writeFile(filePath, content, 'utf-8');
+    return filePath;
+  };
+
+  it('しきい値を満たしていれば 0 を返す', async () => {
+    const summary = await write('summary.json', summaryJson({ 'src/a.ts': 90 }, 90));
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    expect(await main(['--summary', summary, '--min-lines', '85'])).toBe(0);
+  });
+
+  it('しきい値を下回ったら 1 を返す', async () => {
+    const summary = await write('summary.json', summaryJson({ 'src/a.ts': 10 }, 10));
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    expect(await main(['--summary', summary, '--min-lines', '85'])).toBe(1);
+  });
+
+  it('--out に書き出す', async () => {
+    const summary = await write('summary.json', summaryJson({ 'src/a.ts': 90 }, 90));
+    const out = path.join(tmp.dir, 'comment.md');
+
+    expect(await main(['--summary', summary, '--out', out])).toBe(0);
+    expect(await readFile(out, 'utf-8')).toContain(COMMENT_MARKER);
+  });
+
+  it('カバレッジのファイルがなければ 2 を返す', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    expect(await main(['--summary', path.join(tmp.dir, 'missing.json')])).toBe(2);
+  });
+
+  it('引数が不正なら 2 を返す', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    expect(await main(['--nope'])).toBe(2);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,12 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       include: ['scripts/**/*.ts', 'src/lib/**/*.ts'],
-      exclude: ['**/*.test.ts'],
-      reporter: ['text', 'html'],
+      // posts.ts は astro:content を読むためテストから import できない。
+      // 常に0%として集計されると全体の数字がしきい値判定に使えなくなる
+      exclude: ['**/*.test.ts', 'src/lib/posts.ts'],
+      // json-summary は scripts/coverage-report.ts が読んで
+      // プルリクにコメントする数字のもと
+      reporter: ['text', 'html', 'json-summary'],
     },
   },
 });


### PR DESCRIPTION
## 概要

CI/CD まわりの改善です。古い Action と Node の更新、テストカバレッジのPRコメント、異常検知、セットアップの共通化を行いました。

## 1. Action のバージョン更新

すべて最新のメジャーに上げました。

| Action | before | after |
| --- | --- | --- |
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/upload-pages-artifact` | v3 | **v5** |

あわせて `dependabot.yml` を月次→週次にし、`actions/*` の更新を1本のPRにまとめるようグループ化しました。TypeScript 移行で不要になった `pip` の監視も外しています。

## 2. Node のバージョン更新（22 → 24）

Node 22 は Maintenance LTS に落ちているため、Active LTS の **24** に移しました。バージョンを持つのは2か所だけなので、両方をそろえています。

- `.github/actions/setup` の `node-version` 既定値（CI 全体がこれを使う）
- `Dockerfile` / `Dockerfile.production` の `node:24-slim`

Node 24.18.0 で型チェック・テスト189件・カバレッジ・`astro build` と Pagefind の索引作成・公開前ゲートまで通ることを確認済みです。glibc に依存する Pagefind のバイナリも問題なく動きました（`node:24-slim` を Alpine にしない理由がこれです）。

## 3. セットアップの共通化

4つのワークフローが同じ checkout + Node セットアップを繰り返し、3つが同じ失敗報告の shell を写経していたので composite action にまとめました。

- `.github/actions/setup` — Node のセットアップと `npm ci`。Node のバージョンを上げるときはここだけ直せばよい
- `.github/actions/report-failure` — 失敗を issue に記録する。同じラベルの open な issue があれば新規に立てずコメントを追記する（毎日失敗すると issue が積み上がるため）

## 4. テストカバレッジをPRにコメント

- `scripts/coverage-report.ts` が `coverage-summary.json` を Markdown にします（全体の数字＋ファイル別の内訳を折りたたみで、低い順に並べる）
- `test.yml` が目印 `<!-- coverage-report -->` でコメントを探して**1つだけ更新**します。再pushしてもPRが埋まりません
- 行カバレッジが **85%**（現状は約91%）を下回るとPRを失敗させます。しきい値割れでもコメントは先に投稿してから失敗させるので、数字は必ず見えます
- フォークからのPRは `GITHUB_TOKEN` が読み取り専用でコメントできないため、同じ内容をジョブサマリにも出しています
- `src/lib/posts.ts` はカバレッジ集計から除外しました。`astro:content` を読むためテストできず、常に0%として数えると全体の数字がしきい値に使えなくなるためです

<details><summary>コメントの見た目（実データ）</summary>

| 対象 | Lines | Statements | Functions | Branches |
| --- | ---: | ---: | ---: | ---: |
| 🟢 **全体** | 91.12% | 91.12% | 93.33% | 83.75% |

</details>

## 5. 異常検知

公開前ゲート（`validate-build.ts`）はビルドした結果しか見ないので、**静かな壊れ方**には気づけません。cron が止まった、実行は緑なのに記事が増えていない、Pages が古い成果物を出し続けている、といった状態です。

`health-check.yml`（毎日 10:00 JST）と `scripts/check-site-health.ts` を追加しました。**公開されている** `feed.xml` を外から取りに行き、

- 取得できるか / XML として壊れていないか
- 空タイトル・URL重複・リンク欠けがないか
- 最新記事が **36時間**以上前になっていないか

を確かめ、問題があれば `site-health` ラベルの issue を立てます。

36時間の根拠: 記事の date は実行時刻ではなく対象日の 09:00 JST に固定されている（`postDateStamp`）ので、健全なら点検時点の最新記事は必ず約25時間前です。1回飛ぶと約49時間前になるため、その中間を取っています。

## 6. ワークフロー自体の検査

`test.yml` に **actionlint** のジョブを追加しました。式の書き間違いや存在しないキーが、次回のスケジュール実行ではなくPRで落ちます。

## 7. 誤報の修正（バグ）

`report-deploy-failure` が bare な `failure()` で判定していました。ビルドが落ちて `deploy` がスキップされたときにも `failure()` は true になるため、**記事は何もコミットされていないのに「コミットは成功したが公開に失敗しました」という誤った issue** が立つ状態でした。`needs.deploy.result == 'failure'` で明示的に判定するようにしています。

あわせて、各 shell ステップを `set -euo pipefail` に統一し、`weekly-digest.yml` の `inputs.week_ending` をコマンド行に直接展開せず env 経由に変えました。

## 検証

すべて **Node 24.18.0** でローカル実行済みです。

- `npm run check` — 0 errors
- `npm test` — 189 passed（新規テスト48件を含む）
- `npm run test:coverage` — 全体 91.12%（しきい値85%）
- `actionlint` — 指摘なし
- `npm run build` + `npm run validate` — 検証OK（Pagefind の索引作成を含む）
- `npm run health-check` — ビルドした実物の `feed.xml` をローカルで配信して、正常判定と「止まっている」判定の両方を確認

未確認: Docker イメージのビルドは実行環境に Docker デーモンが無いため試せていません。ただし `npm ci` と Pagefind の glibc バイナリは同じ Debian 系の Node 24 上で動作確認しています。

## テスト

- `tests/coverage-report.test.ts`（23件）— パースの相対パス化、低い順の並び、しきい値の判定、終了コード
- `tests/check-site-health.test.ts`（25件）— Atomの解析、古さ・未来日付・重複URL・空タイトルの検出、取得失敗時の打ち切り