### PR TITLE
style: 記事まとめのタイトルを1行に収める

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -170,10 +170,16 @@ a {
 .post-page__header h1 {
   margin: 0;
   color: var(--fg);
-  font-size: 1.72rem;
+  /*
+   * 幅に合わせて縮めることで、タイトルが1行に収まる画面幅を広げている
+   * （狭い画面では 1.15rem で止まり、そこから先は折り返す）。
+   */
+  font-size: clamp(1.15rem, 2.9vw, 1.72rem);
   font-weight: var(--text-weight);
   letter-spacing: var(--title-letter-spacing);
   line-height: 1.4;
+  /* 折り返すしかない幅でも、末尾の1文字だけが次の行に落ちないようにする */
+  text-wrap: balance;
 }
 
 .eyebrow,
@@ -272,15 +278,25 @@ a {
 }
 
 /* Single post */
+/*
+ * 記事全体は --content-max まで広げ、読み物としての行長は本文とナビだけを
+ * --copy-max に絞って保つ。タイトル（記事まとめの見出し）は日付や件数まで
+ * 入って長いので、--copy-max のままだと必ず2行に折り返してしまう。
+ */
 .post-page {
   display: grid;
   gap: 1.8rem;
-  max-width: var(--copy-max);
+  max-width: var(--content-max);
 }
 
 .post-page__header {
   display: grid;
   gap: 0.92rem;
+}
+
+.post-body,
+.post-nav {
+  max-width: var(--copy-max);
 }
 
 .post-page__meta {
@@ -697,6 +713,12 @@ a {
 .empty-state {
   width: fit-content;
   max-width: 100%;
+  /*
+   * width: fit-content と border-box を組み合わせると、下の padding
+   * （ホバーの塗りしろ）が内容の幅から差し引かれ、収まるはずのタイトルでも
+   * 最後の1文字が次の行に落ちる。padding を外側に付けて実幅を保つ。
+   */
+  box-sizing: content-box;
   margin: -0.16rem -0.28rem;
   background-image: var(--hover-shape), var(--hover-surface);
   background-position:
@@ -772,8 +794,8 @@ a {
     padding-block: 6rem 4rem;
   }
 
-  .page-heading h1,
-  .post-page__header h1 {
+  /* 記事タイトルは clamp() で幅に追従させるので、ここでは固定しない */
+  .page-heading h1 {
     font-size: 1.48rem;
   }
 


### PR DESCRIPTION
「はてなブックマーク YYYY年MM月DD日 の記事まとめ (N件)」というタイトルが
一覧でも記事ページでも2行に折り返していたため、次の3点を直した。

- ホバーの塗りしろ用 padding を持つ要素を content-box にした。
  width: fit-content と border-box の組み合わせでは padding が内容幅から
  差し引かれ、収まるはずの一覧タイトルでも末尾の1文字が次行に落ちていた
- 記事ページは --content-max まで広げ、行長を保ちたい本文とナビだけを
  --copy-max に絞った。タイトルが --copy-max では必ず折り返すため
- 記事タイトルの font-size を clamp() にして幅に追従させ、
  720px 用の固定サイズ指定を外した。折り返す幅では text-wrap: balance

Chromium で計測したところ、一覧・アーカイブ・記事ページのタイトルは
いずれも幅500px以上で1行に収まり、横スクロールも発生しない。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DG2XkaniHYMthzhA4TdFzT