### PR TITLE
URLのパーセントエンコードで日本語が崩れる箇所を直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,10 @@ docker compose run --rm scripts npm test
     `posts.ts` から再エクスポートしているので import 元は変わらない
   - `src/lib/bookmarks.ts`: 本文からブックマーク見出しを抽出（feed と `/sites/` が共用）
   - `src/lib/feed.ts` / `src/lib/xml.ts`: フィードの summary 生成と XML エスケープ
+  - `src/lib/url.ts`: 表示用のURL整形（パーセントエンコードのデコード）。はてなのRSSは
+    元記事のタイトルが無いブックマークのタイトルをURLのまま返し、そのURLの日本語は
+    `%E7%99%BB%E5%A3%87...` のままなので、見出し・一覧・フィードに出す前にここで戻す。
+    リンク先のURL自体は書き換えない
   - `src/lib/*.test.ts`: vitest（`npm test`）。astro を読まないモジュールだけが対象
   - `src/layouts/`: `BaseLayout.astro`, `PostLayout.astro`
   - `src/components/`: `Header`, `Footer`, `PostList`, `Pagination`,
@@ -157,8 +161,9 @@ docker compose run --rm scripts npm test
     正規化）, `article.ts`（cheerio による本文抽出）, `boilerplate.ts`（ログイン誘導や
     ボット判定ページを本文と取り違えないための判定）, `sources/twitter.ts`（x.com の
     ポスト取得）, `summary.ts`（GitHub Actions のジョブサマリ）, `abort.ts`（`AbortRun`）,
-    `xml-node.ts`, `fs.ts`, `logger.ts`。日次記事の見出しの読み取りは
-    `src/lib/bookmarks.ts` を直接 import する（フィードや `/sites/` と同じ実装を使う）
+    `markdown.ts`（壊れないMarkdownリンクの組み立て）, `xml-node.ts`, `fs.ts`, `logger.ts`。
+    日次記事の見出しの読み取りは `src/lib/bookmarks.ts` を、表示用のタイトル整形は
+    `src/lib/url.ts` を直接 import する（フィードや `/sites/` と同じ実装を使う）
   - `tests/`: vitest tests for the scripts (Gemini SDK と fetch はモックする)
 - **CI/CD**: `.github/workflows/` for automated deployment and content updates, plus
   `.github/actions/` — the composite actions (`setup`, `report-failure`) the workflows share
@@ -290,7 +295,14 @@ take injectable `direct` / `viaJina`) — ESM の export は差し替えられ�
    `permalink` are all derived from the bookmark date (`postDateStamp()` pins the time to
    09:00 JST = 00:00 UTC),
    never from the run time — otherwise a manual run outside the cron window shifts the
-   displayed date, which is rendered in UTC, one day away from the permalink
+   displayed date, which is rendered in UTC, one day away from the permalink.
+   見出しのリンクは `scripts/lib/markdown.ts` の `markdownLink()` で組み立てる:
+   タイトルの `[` `]` をエスケープし、閉じない括弧や空白を含むURL（例:
+   `...&ct=t(EMAIL_CAMPAIGN`）は `<...>` で囲む。裸のまま書くと CommonMark が
+   リンクとして読めず、記事にURLの文字列がそのまま出る。URL自体は
+   パーセントエンコードし直さない（別のURLになりうるため）。
+   タイトルがURLのままのブックマークは `displayTitle()` でデコードしてから見出しにする。
+   `tests/posts-integrity.test.ts` が `_posts/` 全体のリンク宛先を検査して再発を止める
 5. **Weekly digest**: `build-weekly-digest.ts` (run by `weekly-digest.yml` every Monday
    09:30 JST) reads the last 7 daily posts from `_posts/`, pulls the bookmark headings out
    of them — both the current `## [title](url)` form and the legacy `## 1. title` +

--- a/_posts/2025-09-25-hatena-bookmarks.md
+++ b/_posts/2025-09-25-hatena-bookmarks.md
@@ -38,7 +38,7 @@ DevOpsDays Tokyo 2025では、249名の参加者、36のセッション、43名�
 
 ## 2. Qiita Conference 2025 Autumn（キータ カンファレンス 2025 オータム） - Qiita
 
-**URL:** [https://qiita.com/official-campaigns/conference/2025-autumn?utm_source=Qiita+%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9&utm_campaign=0debef982e-EMAIL_CAMPAIGN_2025_09_25&utm_medium=email&utm_term=0_e44feaa081-0debef982e-64544897&ct=t(EMAIL_CAMPAIGN_2025_09_25](https://qiita.com/official-campaigns/conference/2025-autumn?utm_source=Qiita+%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9&utm_campaign=0debef982e-EMAIL_CAMPAIGN_2025_09_25&utm_medium=email&utm_term=0_e44feaa081-0debef982e-64544897&ct=t(EMAIL_CAMPAIGN_2025_09_25)
+**URL:** [https://qiita.com/official-campaigns/conference/2025-autumn?utm_source=Qiita+%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9&utm_campaign=0debef982e-EMAIL_CAMPAIGN_2025_09_25&utm_medium=email&utm_term=0_e44feaa081-0debef982e-64544897&ct=t(EMAIL_CAMPAIGN_2025_09_25](<https://qiita.com/official-campaigns/conference/2025-autumn?utm_source=Qiita+%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9&utm_campaign=0debef982e-EMAIL_CAMPAIGN_2025_09_25&utm_medium=email&utm_term=0_e44feaa081-0debef982e-64544897&ct=t(EMAIL_CAMPAIGN_2025_09_25>)
 
 ### AI要約
 

--- a/_posts/2025-11-17-hatena-bookmarks.md
+++ b/_posts/2025-11-17-hatena-bookmarks.md
@@ -23,7 +23,7 @@ excerpt: "はてなブックマークで気になった記事をAIで要約し�
 はてなブックマークで気になった記事をAIで要約してお届けします。
 2025年11月17日分の7件の記事をまとめました。
 
-## 1. https://2025.agilejapan.jp/wp-content/uploads/2025/11/1114_1300-1320_MSOL_AgileJapan2025_%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99_%E6%8F%90%E5%87%BA%E7%89%88.pdf
+## 1. https://2025.agilejapan.jp/wp-content/uploads/2025/11/1114_1300-1320_MSOL_AgileJapan2025_登壇資料_提出版.pdf
 
 **URL:** [https://2025.agilejapan.jp/wp-content/uploads/2025/11/1114_1300-1320_MSOL_AgileJapan2025_%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99_%E6%8F%90%E5%87%BA%E7%89%88.pdf](https://2025.agilejapan.jp/wp-content/uploads/2025/11/1114_1300-1320_MSOL_AgileJapan2025_%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99_%E6%8F%90%E5%87%BA%E7%89%88.pdf)
 

--- a/scripts/build-weekly-digest.ts
+++ b/scripts/build-weekly-digest.ts
@@ -35,6 +35,7 @@ import {
 import { buildFrontMatter, splitFrontMatter } from './lib/frontmatter.ts';
 import { fileExists } from './lib/fs.ts';
 import { describeError, logger } from './lib/logger.ts';
+import { markdownLink } from './lib/markdown.ts';
 
 export const POSTS_DIR = '_posts';
 
@@ -151,7 +152,9 @@ export function renderPost(digests: DailyDigest[], end: CivilDate): string {
   for (const digest of digests) {
     const block = [`## ${formatJapaneseDate(digest.day)} (${digest.bookmarks.length}件)`, ''];
     for (const bookmark of digest.bookmarks) {
-      block.push(bookmark.url ? `- [${bookmark.title}](${bookmark.url})` : `- ${bookmark.title}`);
+      block.push(
+        bookmark.url ? `- ${markdownLink(bookmark.title, bookmark.url)}` : `- ${bookmark.title}`
+      );
     }
     sections.push(block.join('\n'));
   }

--- a/scripts/fetch-and-summarize.ts
+++ b/scripts/fetch-and-summarize.ts
@@ -35,6 +35,7 @@ import { buildFrontMatter } from './lib/frontmatter.ts';
 import { fileExists } from './lib/fs.ts';
 import { decodeBody, fetchBytes, fetchText, isTextLike, USER_AGENT } from './lib/http.ts';
 import { describeError, logger } from './lib/logger.ts';
+import { markdownLink } from './lib/markdown.ts';
 import { parseFeed, type FeedEntry } from './lib/rss.ts';
 import {
   fetchTweet,
@@ -44,6 +45,8 @@ import {
   tweetTitle,
 } from './lib/sources/twitter.ts';
 import { appendJobSummary } from './lib/summary.ts';
+// 表示用のタイトル整形はサイト側（フィード・/sites/）と同じ実装を使う
+import { displayTitle } from '../src/lib/url.ts';
 
 export const RSS_URL = 'https://b.hatena.ne.jp/Buchi_6uclz1/rss';
 export const GEMINI_MODEL = 'gemini-2.5-flash';
@@ -410,7 +413,8 @@ export function buildPrompt(bookmark: Bookmark, articleText: string): string {
     summary_max: String(SUMMARY_MAX_CHARS),
     point_max: String(POINT_MAX_CHARS),
     max_points: String(MAX_POINTS),
-    title: bookmark.title,
+    // パーセントエンコードのままのタイトルは Gemini にも読めないので戻す
+    title: displayTitle(bookmark.title),
     url: bookmark.url,
     content: articleText,
   };
@@ -567,7 +571,13 @@ export function renderPost(digests: SummarizedBookmark[], target: CivilDate): st
   // 本文の導入文は置かない。タイトルに日付と件数が入っており、
   // 一覧やフィードには excerpt が出るので、記事側で繰り返すと読む量が増えるだけ。
   const sections = digests.map(([bookmark, entry]) => {
-    const block = [`## [${bookmark.title}](${bookmark.url})`, '', entry.summary];
+    // タイトルがURLのまま（元記事のタイトルが取れなかった）ときは
+    // パーセントエンコードを解いて、見出しの日本語が読める形にする
+    const block = [
+      `## ${markdownLink(displayTitle(bookmark.title), bookmark.url)}`,
+      '',
+      entry.summary,
+    ];
     if (entry.points.length > 0) {
       block.push('');
       block.push(...entry.points.map((point) => `- ${point}`));
@@ -717,8 +727,11 @@ async function reportSkipped(skipped: SkippedBookmark[], total: number): Promise
     logger.warn(`  - ${bookmark.url}: ${reason}`);
   }
 
+  // `|` を含むタイトルは表の列を割ってしまうのでエスケープする
+  const cell = (text: string) => displayTitle(text).replace(/\|/g, '\\|');
   const rows = skipped.map(
-    ({ bookmark, reason }) => `| ${bookmark.title || '(タイトルなし)'} | ${bookmark.url} | ${reason} |`
+    ({ bookmark, reason }) =>
+      `| ${bookmark.title ? cell(bookmark.title) : '(タイトルなし)'} | ${bookmark.url} | ${reason} |`
   );
   await appendJobSummary(
     [

--- a/scripts/lib/markdown.ts
+++ b/scripts/lib/markdown.ts
@@ -1,0 +1,50 @@
+/**
+ * 生成する記事のMarkdownを組み立てる小道具。
+ *
+ * ブックマークのタイトルもURLも外部から来る文字列なので、そのまま
+ * `[タイトル](URL)` に流し込むとリンクが壊れることがある。
+ * 実例: `...&ct=t(EMAIL_CAMPAIGN_2025_09_25` のように閉じない `(` を含むURLは
+ * CommonMark のリンクとして読めず、記事にURLがそのまま出てしまう
+ * （_posts/2025-09-25-hatena-bookmarks.md にその状態で残っている）。
+ */
+
+/**
+ * リンクの `[...]` に入れるテキスト。
+ *
+ * `[速報]` のような角括弧を含むタイトルはリンクの範囲を壊すのでエスケープする。
+ */
+export function escapeLinkText(text: string): string {
+  return text.replace(/([\\[\]])/g, '\\$1');
+}
+
+/**
+ * リンクの `(...)` に入れる宛先。
+ *
+ * 括弧や空白を含むURLは `<...>` で囲む形にする。パーセントエンコードで
+ * 書き換えるとURL自体が別物になりうるため、囲むだけにしてURLは変えない。
+ * `<` `>` はURLに現れてはいけない文字なので、含むときだけエンコードする。
+ */
+export function markdownLinkDestination(url: string): string {
+  const escaped = url.replace(/</g, '%3C').replace(/>/g, '%3E');
+  return needsAngleBrackets(escaped) ? `<${escaped}>` : escaped;
+}
+
+/** 空白を含む、または括弧の対応が取れていないURLは裸で書けない */
+function needsAngleBrackets(url: string): boolean {
+  if (/\s/.test(url)) return true;
+
+  let depth = 0;
+  for (const char of url) {
+    if (char === '(') depth += 1;
+    else if (char === ')') {
+      depth -= 1;
+      if (depth < 0) return true;
+    }
+  }
+  return depth !== 0;
+}
+
+/** 壊れないMarkdownリンク */
+export function markdownLink(text: string, url: string): string {
+  return `[${escapeLinkText(text)}](${markdownLinkDestination(url)})`;
+}

--- a/src/lib/bookmarks.test.ts
+++ b/src/lib/bookmarks.test.ts
@@ -63,6 +63,26 @@ describe('extractBookmarks', () => {
     expect(extractBookmarkTitles(body)).toEqual(['useState を 読み解く']);
   });
 
+  it('タイトルがURLのままの見出しはデコードして読める形にする', () => {
+    // 元記事のタイトルが取れなかったブックマークは、はてなのRSSが返すURLが
+    // そのままタイトルになる。パーセントエンコードのままだと日本語が読めない
+    const body =
+      '## 1. https://example.com/%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99.pdf';
+    expect(extractBookmarkTitles(body)).toEqual(['https://example.com/登壇資料.pdf']);
+  });
+
+  it('URLに括弧が含まれていても最後まで取り出す', () => {
+    const url = 'https://ja.wikipedia.org/wiki/%E5%9C%B0%E6%96%B9%E7%97%85_(%E6%97%A5%E6%9C%AC)';
+    const body = ['## 1. 地方病', '', `**URL:** [地方病](${url})`].join('\n');
+    expect(extractBookmarks(body)).toEqual([{ title: '地方病', url }]);
+  });
+
+  it('<> で囲まれた宛先からもURLを取り出す', () => {
+    const url = 'https://example.com/a?ct=t(EMAIL';
+    const body = ['## 1. キャンペーン', '', `**URL:** [リンク](<${url}>)`].join('\n');
+    expect(extractBookmarks(body)).toEqual([{ title: 'キャンペーン', url }]);
+  });
+
   it('見出しが無い本文では空になる', () => {
     expect(extractBookmarkTitles('ただの段落です。\n\n- 箇条書き')).toEqual([]);
   });

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -6,29 +6,47 @@
  * 生成時期によって書式が違うため、常に本文から拾う方が揃う。
  */
 
+import { displayTitle } from './url';
+
 export interface BookmarkRef {
   title: string;
   /** 旧形式（`## 1. タイトル`）にはURLが無いため任意 */
   url?: string;
 }
 
+// リンクの宛先。`<...>` で囲む形（括弧や空白を含むURL）と裸の形の両方を受ける。
+// 裸の形は貪欲に読んで行末の `)` までを宛先とし、URLの中の対応の取れた括弧
+// （例: `.../wiki/地方病_(日本住血吸虫症)`）が途中で切れないようにする。
+const DESTINATION = '(?:<(https?:\\/\\/[^>]+)>|(https?:\\/\\/.+))';
+
 // 記事内の `## 要点` `## 詳細な要約` のようなセクション見出しを拾わないよう、
 // リンク形式か採番形式のみを対象にする。
 const HEADING_PATTERNS: { pattern: RegExp; hasUrl: boolean }[] = [
   // 現在の形式: ## [タイトル](https://example.com/)
-  { pattern: /^##\s+\[(.+)\]\((https?:\/\/[^)]+)\)\s*$/, hasUrl: true },
+  { pattern: new RegExp(`^##\\s+\\[(.+)\\]\\(${DESTINATION}\\)\\s*$`), hasUrl: true },
   // 旧形式: ## 1. タイトル
   { pattern: /^##\s+\d+\.\s+(.+?)\s*$/, hasUrl: false },
 ];
 
 // 旧形式は見出しにURLを持たず、直後の本文に `**URL:** [...](...)` の行を置いている。
 // 既存記事はすべてこの形式なので、見出しの後に続くこの行からURLを補う。
-const URL_LINE_PATTERN = /^\*\*URL:\*\*\s*\[[^\]]*\]\((https?:\/\/[^)]+)\)/;
+const URL_LINE_PATTERN = new RegExp(
+  `^\\*\\*URL:\\*\\*\\s*\\[[^\\]]*\\]\\(${DESTINATION}\\)\\s*$`
+);
+
+/** 正規表現のどちらの宛先グループに入ったかを見て、URLを取り出す */
+const destinationOf = (match: RegExpExecArray, first: number) =>
+  match[first] ?? match[first + 1];
 
 const collapse = (text: string) => text.replace(/\s+/g, ' ').trim();
 
-/** 強調記法やバッククォートは一覧では読みにくいので落とす */
-const cleanTitle = (raw: string) => collapse(raw.replace(/[*_`]/g, ''));
+/**
+ * 強調記法やバッククォートは一覧では読みにくいので落とし、
+ * タイトルがURLのままのもの（元記事のタイトルが取れなかったブックマーク）は
+ * パーセントエンコードを解いて日本語が読めるようにする。
+ */
+const cleanTitle = (raw: string) =>
+  displayTitle(collapse(raw.replace(/[*_`]/g, '').replace(/\\([\\[\]])/g, '$1')));
 
 /** 記事本文からブックマークを出現順に取り出す */
 export function extractBookmarks(body: string): BookmarkRef[] {
@@ -47,7 +65,7 @@ export function extractBookmarks(body: string): BookmarkRef[] {
       const title = cleanTitle(match[1]!);
       if (title) {
         const bookmark: BookmarkRef = hasUrl
-          ? { title, url: match[2] }
+          ? { title, url: destinationOf(match, 2) }
           : { title };
         bookmarks.push(bookmark);
         pending = bookmark;
@@ -60,7 +78,7 @@ export function extractBookmarks(body: string): BookmarkRef[] {
 
     if (pending && !pending.url) {
       const urlMatch = URL_LINE_PATTERN.exec(line);
-      if (urlMatch) pending.url = urlMatch[1];
+      if (urlMatch) pending.url = destinationOf(urlMatch, 1);
     }
   }
 

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodePercentEncoding, displayTitle, isUrlLike } from './url';
+
+describe('decodePercentEncoding', () => {
+  it('パーセントエンコードされた日本語を戻す', () => {
+    expect(
+      decodePercentEncoding('https://ja.wikipedia.org/wiki/%E5%9C%B0%E6%96%B9%E7%97%85')
+    ).toBe('https://ja.wikipedia.org/wiki/地方病');
+  });
+
+  it('エンコードされていない文字列はそのまま', () => {
+    expect(decodePercentEncoding('https://example.com/a-b_c')).toBe('https://example.com/a-b_c');
+  });
+
+  it('壊れた並びはその部分だけ元のまま残す', () => {
+    // %zz は解けない。全体を decodeURIComponent すると例外になり、
+    // 読める部分まで生のままになってしまう
+    expect(decodePercentEncoding('https://example.com/%zz/%E6%97%A5')).toBe(
+      'https://example.com/%zz/日'
+    );
+  });
+
+  it('途中で切れたUTF-8の並びもその部分だけ残す', () => {
+    expect(decodePercentEncoding('https://example.com/%E3%81/%E6%97%A5')).toBe(
+      'https://example.com/%E3%81/日'
+    );
+  });
+
+  it('制御文字になる並びはデコードしない', () => {
+    expect(decodePercentEncoding('https://example.com/a%0Ab')).toBe('https://example.com/a%0Ab');
+  });
+
+  it('スペースや記号のエンコードも戻す', () => {
+    expect(decodePercentEncoding('%E6%97%A5%20%28%E6%9C%AC%29')).toBe('日 (本)');
+  });
+});
+
+describe('isUrlLike', () => {
+  it('URLだけの文字列を判定する', () => {
+    expect(isUrlLike('https://example.com/a')).toBe(true);
+    expect(isUrlLike('  http://example.com/a  ')).toBe(true);
+  });
+
+  it('URLを含むだけの文章はURLではない', () => {
+    expect(isUrlLike('記事 https://example.com/a について')).toBe(false);
+    expect(isUrlLike('100%E3%81 の話')).toBe(false);
+    expect(isUrlLike('')).toBe(false);
+  });
+});
+
+describe('displayTitle', () => {
+  it('タイトルがURLのときだけデコードする', () => {
+    expect(displayTitle('https://example.com/%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99.pdf')).toBe(
+      'https://example.com/登壇資料.pdf'
+    );
+  });
+
+  it('通常のタイトルは % を含んでいても触らない', () => {
+    expect(displayTitle('CPU使用率が100%E5に見える話')).toBe('CPU使用率が100%E5に見える話');
+  });
+});

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,45 @@
+/**
+ * URLの見た目を整える処理。
+ *
+ * はてなのRSSはブックマークのタイトルをURLのまま返すことがあり、そのURLは
+ * 日本語部分がパーセントエンコードされている（`%E7%99%BB%E5%A3%87...`）。
+ * そのまま見出しや一覧に出すと日本語が読めないので、表示に使う文字列は
+ * ここでデコードしてから渡す。リンク先として使うURL自体は書き換えない。
+ */
+
+/** 表示に出すと崩れる制御文字（デコード結果に混ざったら元の表記のまま残す） */
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/;
+
+/**
+ * パーセントエンコードされた並びを元の文字に戻す。
+ *
+ * 途中に壊れた並び（`%zz` や切れた `%E3%81`）があってもそこだけ元のまま残し、
+ * 読める部分は読めるようにする。`decodeURIComponent` を文字列全体にかけると
+ * 壊れた並びが1つあるだけで例外になり、全体が生のまま出てしまう。
+ */
+export function decodePercentEncoding(value: string): string {
+  return value.replace(/(?:%[0-9A-Fa-f]{2})+/g, (sequence) => {
+    try {
+      const decoded = decodeURIComponent(sequence);
+      return CONTROL_CHARS.test(decoded) ? sequence : decoded;
+    } catch {
+      return sequence;
+    }
+  });
+}
+
+/** 文字列がURLそのものか（タイトルがURLで埋められているかの判定） */
+export function isUrlLike(value: string): boolean {
+  return /^https?:\/\/\S+$/i.test(value.trim());
+}
+
+/**
+ * 見出しや一覧に出すタイトル。
+ *
+ * タイトルがURLで埋まっているとき（元記事のタイトルが取れなかったとき）だけ
+ * パーセントエンコードを解いて、日本語が読める形にする。
+ * 通常のタイトルは `%` を含んでいても文章なので触らない。
+ */
+export function displayTitle(title: string): string {
+  return isUrlLike(title) ? decodePercentEncoding(title) : title;
+}

--- a/tests/fetch-and-summarize.test.ts
+++ b/tests/fetch-and-summarize.test.ts
@@ -576,6 +576,34 @@ describe('renderPost', () => {
     expect(body).toContain('- 点B');
   });
 
+  it('タイトルがURLのままなら日本語が読める形にする', () => {
+    // 元記事のタイトルが取れなかったブックマークは、はてなのRSSが返す
+    // パーセントエンコードされたURLがそのままタイトルになる
+    const encoded: SummarizedBookmark[] = [
+      [
+        {
+          title: 'https://example.com/%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99.pdf',
+          url: 'https://example.com/%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99.pdf',
+        },
+        digest('資料の要約。'),
+      ],
+    ];
+
+    expect(bodyOf(renderPost(encoded, target))).toContain(
+      '## [https://example.com/登壇資料.pdf](https://example.com/%E7%99%BB%E5%A3%87%E8%B3%87%E6%96%99.pdf)'
+    );
+  });
+
+  it('閉じない括弧を含むURLでもリンクが壊れない', () => {
+    const tricky: SummarizedBookmark[] = [
+      [{ title: 'キャンペーン', url: 'https://example.com/a?ct=t(EMAIL' }, digest('要約。')],
+    ];
+
+    expect(bodyOf(renderPost(tricky, target))).toContain(
+      '## [キャンペーン](<https://example.com/a?ct=t(EMAIL>)'
+    );
+  });
+
   it('朝にパラッと読める分量に収まっている', () => {
     const body = bodyOf(renderPost(digests, target));
 

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeLinkText, markdownLink, markdownLinkDestination } from '../scripts/lib/markdown.ts';
+import { extractBookmarks } from '../src/lib/bookmarks.ts';
+
+describe('markdownLinkDestination', () => {
+  it('普通のURLはそのまま', () => {
+    expect(markdownLinkDestination('https://example.com/a?b=c')).toBe('https://example.com/a?b=c');
+  });
+
+  it('対応の取れた括弧を含むURLもそのまま（CommonMarkが読める）', () => {
+    expect(markdownLinkDestination('https://ja.wikipedia.org/wiki/A_(B)')).toBe(
+      'https://ja.wikipedia.org/wiki/A_(B)'
+    );
+  });
+
+  it('閉じない括弧を含むURLは <> で囲む', () => {
+    expect(markdownLinkDestination('https://example.com/a?ct=t(EMAIL')).toBe(
+      '<https://example.com/a?ct=t(EMAIL>'
+    );
+  });
+
+  it('閉じ括弧が先に来るURLも <> で囲む', () => {
+    expect(markdownLinkDestination('https://example.com/a)b')).toBe('<https://example.com/a)b>');
+  });
+
+  it('空白を含むURLは <> で囲む', () => {
+    expect(markdownLinkDestination('https://example.com/a b')).toBe('<https://example.com/a b>');
+  });
+
+  it('<> はURLに現れてはいけないのでエンコードする', () => {
+    expect(markdownLinkDestination('https://example.com/<a>')).toBe('https://example.com/%3Ca%3E');
+  });
+});
+
+describe('escapeLinkText', () => {
+  it('角括弧をエスケープする', () => {
+    expect(escapeLinkText('[速報] 新機能')).toBe('\\[速報\\] 新機能');
+  });
+});
+
+describe('markdownLink', () => {
+  it('壊れたリンクにならず、抽出側でも同じURLに戻る', () => {
+    const url = 'https://example.com/a?ct=t(EMAIL';
+    const body = `## ${markdownLink('[速報] タイトル', url)}`;
+
+    expect(extractBookmarks(body)).toEqual([{ title: '[速報] タイトル', url }]);
+  });
+
+  it('対応の取れた括弧を含むURLも欠けずに抽出できる', () => {
+    const url = 'https://ja.wikipedia.org/wiki/%E5%9C%B0%E6%96%B9%E7%97%85_(%E6%97%A5%E6%9C%AC)';
+    const body = `## ${markdownLink('地方病', url)}`;
+
+    expect(extractBookmarks(body)).toEqual([{ title: '地方病', url }]);
+  });
+});

--- a/tests/posts-integrity.test.ts
+++ b/tests/posts-integrity.test.ts
@@ -144,3 +144,67 @@ describe('_posts', () => {
     expect(failures, `日付の不一致:\n${failures.join('\n')}`).toEqual([]);
   });
 });
+
+describe('_posts の本文', () => {
+  it('Markdownリンクの宛先が壊れていない', async () => {
+    // 閉じない `(` や空白を含むURLを裸で書くと CommonMark がリンクとして読めず、
+    // 記事にURLの文字列がそのまま出る。生成側(scripts/lib/markdown.ts)は
+    // そうしたURLを `<...>` で囲むが、過去記事も含めて崩れていないことを見張る。
+    const failures: string[] = [];
+
+    for (const { name, body } of await readPostBodies()) {
+      body.split('\n').forEach((line, index) => {
+        for (const destination of linkDestinations(line)) {
+          if (destination.broken) {
+            failures.push(`${name}:${index + 1}: リンクの宛先が読めない: ${destination.text}`);
+          }
+        }
+      });
+    }
+
+    expect(failures, `壊れたリンク:\n${failures.join('\n')}`).toEqual([]);
+  });
+});
+
+async function readPostBodies(): Promise<{ name: string; body: string }[]> {
+  const names = (await readdir(POSTS_DIR)).filter((name) => name.endsWith('.md')).sort();
+
+  return Promise.all(
+    names.map(async (name) => {
+      const raw = await readFile(path.join(POSTS_DIR, name), 'utf-8');
+      return { name, body: splitFrontMatter(raw).body };
+    })
+  );
+}
+
+/**
+ * 行の中の `](...)` を CommonMark と同じ読み方で拾う。
+ * 宛先は対応の取れた括弧までで、閉じない括弧や空白があるとリンクにならない。
+ */
+function linkDestinations(line: string): { text: string; broken: boolean }[] {
+  const found: { text: string; broken: boolean }[] = [];
+  const pattern = /\]\(\s*(<[^>]*>|[^\s]*)/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(line))) {
+    const raw = match[1]!;
+    // `<...>` で囲まれていれば中身は何でもよい
+    if (raw.startsWith('<')) continue;
+
+    let depth = 0;
+    let closed = false;
+    for (const char of raw) {
+      if (char === '(') depth += 1;
+      else if (char === ')') {
+        if (depth === 0) {
+          closed = true;
+          break;
+        }
+        depth -= 1;
+      }
+    }
+    if (!closed || depth > 0) found.push({ text: raw.slice(0, 120), broken: true });
+  }
+
+  return found;
+}


### PR DESCRIPTION
はてなのRSSは元記事のタイトルが取れないブックマークのタイトルをURLのまま
返すため、日本語が `%E7%99%BB%E5%A3%87...` のまま見出し・/sites/・フィードに
出ていた。表示に使う文字列は `src/lib/url.ts` の displayTitle() で戻す
（壊れた並びはその部分だけ元のまま残す）。リンク先のURLは書き換えない。

あわせてMarkdownリンクの組み立てを scripts/lib/markdown.ts に切り出した。
閉じない括弧を含むURL（`...&ct=t(EMAIL_CAMPAIGN`）を裸で書くと CommonMark が
リンクとして読めず、記事にURLの文字列がそのまま出てしまうため `<...>` で囲む。
タイトルの `[` `]` もエスケープする。

- src/lib/bookmarks.ts: 対応の取れた括弧を含むURL（`/wiki/地方病_(日本住血吸虫症)`）
  が途中で切れていたのを直し、`<...>` 形式の宛先も読めるようにした
- _posts: 上記で壊れていた既存記事2件を修正
- tests/posts-integrity.test.ts: _posts 全体のリンク宛先を検査して再発を止める

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TZN5pmL29UnMBBmyrw9xo8